### PR TITLE
Add MCP server with stdio transport for Claude Desktop integration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,59 @@
+# Monthly Expense Tracker
+
+## Project Overview
+Full-stack personal finance application with Spring Boot backend, PostgreSQL database, React frontend, and comprehensive containerization.
+
+## Architecture
+- **Backend**: Spring Boot 3.x with Java 17 (Amazon Corretto)
+- **Database**: PostgreSQL with JPA/Hibernate
+- **Frontend**: React 18+ (separate repository/service)
+- **Infrastructure**: 
+  - Multi-architecture Docker (AMD64/ARM64)
+  - Kubernetes deployment with NGINX ingress
+  - KIND for local development
+
+## Key Backend Components
+- **Controllers**: REST API endpoints for expense management
+- **Services**: Business logic layer
+- **Repositories**: JPA repositories for data persistence
+- **Entities**: JPA entities for database mapping
+- **DTOs**: Data transfer objects for API responses
+- **Configuration**: Spring Boot configuration classes
+
+## Current Features
+- Expense CRUD operations
+- Category management
+- Multi-architecture Docker builds
+- Kubernetes deployment manifests
+- NGINX ingress configuration
+
+## Development Workflow
+- Maven for dependency management
+- Spring Boot DevTools for hot reload
+- Docker Compose for local development
+- KIND for local Kubernetes testing
+- Multi-stage Dockerfile for optimized builds
+
+## Infrastructure Highlights
+- ARM64 support for 20-40% cost savings on cloud
+- Kubernetes-ready with proper health checks
+- NGINX ingress for load balancing
+- ConfigMap and Secret management
+
+## Common Development Tasks
+- Adding new REST endpoints
+- Database schema migrations
+- Docker image building and testing
+- Kubernetes manifest updates
+- Integration testing setup
+- Performance optimization
+
+## Tech Stack
+- Java 17 (Amazon Corretto)
+- Spring Boot 3.x
+- Spring Data JPA
+- PostgreSQL
+- Maven
+- Docker & Docker Compose
+- Kubernetes & KIND
+- NGINX Ingress

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "projectContext": "Monthly Expense Tracker - Spring Boot REST API with PostgreSQL backend, multi-architecture Docker support (AMD64/ARM64), Kubernetes deployment with NGINX ingress, React frontend.",
+  "permissions": {
+    "allowedTools": [
+      "Read",
+      "Write(src/**)",
+      "Write(*.md)",
+      "Write(Dockerfile*)",
+      "Write(docker-compose.yml)", 
+      "Write(k8s/**)",
+      "Write(pom.xml)",
+      "Bash(mvn :*)",
+      "Bash(./mvnw :*)",
+      "Bash(docker :*)",
+      "Bash(kubectl :*)",
+      "Bash(git :*)",
+      "Bash(npm :*)"
+    ],
+    "deny": [
+      "Write(.env*)",
+      "Write(application-prod.yml)",
+      "Bash(rm -rf :*)",
+      "Bash(sudo :*)",
+      "Write(target/**)"
+    ]
+  }
+}

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -158,6 +158,7 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
+                    <classifier>exec</classifier>
                     <excludes>
                         <exclude>
                             <groupId>org.projectlombok</groupId>

--- a/mcp-server/CLAUDE_DESKTOP_TEST.md
+++ b/mcp-server/CLAUDE_DESKTOP_TEST.md
@@ -1,0 +1,315 @@
+# Testing MCP Server with Claude Desktop
+
+## ✅ Configuration Complete!
+
+Your Claude Desktop is now configured to use the Monthly Expense MCP server.
+
+---
+
+## 🚀 **Step-by-Step Testing**
+
+### **Step 1: Restart Claude Desktop**
+
+**IMPORTANT:** You must restart Claude Desktop for the configuration changes to take effect.
+
+1. **Quit Claude Desktop** completely:
+   - macOS: `Cmd + Q` or Claude Desktop → Quit
+   - Ensure it's fully closed (check Activity Monitor if needed)
+
+2. **Reopen Claude Desktop**:
+   - The MCP server will start automatically when Claude launches
+   - Wait ~30 seconds for the server to initialize
+
+---
+
+### **Step 2: Verify MCP Server is Running**
+
+Open Terminal and check:
+
+```bash
+# Check if MCP server is running
+lsof -i :8082
+
+# Check PostgreSQL port-forward is active
+lsof -i :5432
+
+# View MCP server logs (if needed)
+tail -f /tmp/mcp-server-claude.log
+```
+
+**Expected:** You should see Java processes on both ports.
+
+---
+
+### **Step 3: Check MCP Connection in Claude Desktop**
+
+Look for the **MCP indicator** in Claude Desktop:
+- Bottom right corner should show "5 servers connected" (or similar)
+- Click on it to see the list - "monthly-expenses" should appear
+
+---
+
+### **Step 4: Test with Simple Questions**
+
+Try these questions in Claude Desktop:
+
+#### **Test 1: Basic Query**
+```
+What's my total spending?
+```
+
+**Expected Response:**
+Claude should call the `get_total_spending` tool and tell you:
+- Total amount: $8,724.88
+- Transaction count: 119
+- Average amount: $73.32
+
+---
+
+#### **Test 2: Category Breakdown**
+```
+Show me my spending by category
+```
+
+**Expected Response:**
+Claude should call `get_category_totals` and show:
+- Rent: $3,780.00 (top category)
+- Day Care: $894.50
+- Groceries: $873.80
+- etc.
+
+---
+
+#### **Test 3: Specific Category Query**
+```
+How much did I spend on groceries?
+```
+
+**Expected Response:**
+Claude should call `query_expenses` with category="Groceries" and tell you the total.
+
+---
+
+#### **Test 4: Monthly Analysis**
+```
+Show me my spending for 2025 by month
+```
+
+**Expected Response:**
+Claude should call `get_monthly_summary` with year=2025 and show monthly totals.
+
+---
+
+#### **Test 5: Search Transactions**
+```
+Find all transactions at Woolworths
+```
+
+**Expected Response:**
+Claude should call `search_transactions` with searchText="Woolworths" and list matching transactions.
+
+---
+
+#### **Test 6: Complex Query**
+```
+What are my top 3 spending categories and how much did I spend in December?
+```
+
+**Expected Response:**
+Claude should make multiple tool calls:
+1. `get_category_totals` to get top categories
+2. `query_expenses` with month=12 to get December spending
+
+---
+
+## 🐛 **Troubleshooting**
+
+### **Problem: MCP server not showing in Claude Desktop**
+
+**Solution:**
+1. Check Claude Desktop logs:
+   ```bash
+   tail -100 ~/Library/Logs/Claude/mcp*.log
+   ```
+
+2. Verify config syntax:
+   ```bash
+   cat ~/Library/Application\ Support/Claude/claude_desktop_config.json | jq
+   ```
+
+3. Restart Claude Desktop again
+
+---
+
+### **Problem: "Tool execution failed" errors**
+
+**Solution:**
+1. Ensure PostgreSQL port-forward is running:
+   ```bash
+   lsof -i :5432
+   ```
+
+2. If not running, start it:
+   ```bash
+   kubectl port-forward -n monthly-expense service/monthly-expense-postgresql 5432:5432 &
+   ```
+
+3. Restart Claude Desktop
+
+---
+
+### **Problem: Connection timeout**
+
+**Solution:**
+1. Check MCP server is running:
+   ```bash
+   lsof -i :8082
+   ```
+
+2. Check MCP server logs for errors:
+   ```bash
+   ps aux | grep mcp-server-1.0.0.jar
+   ```
+
+3. Manually start the server to see errors:
+   ```bash
+   cd /Users/sandeepkamath/sandeep/MonthlyExpense/mcp-server
+   java -jar target/mcp-server-1.0.0.jar \
+     --spring.config.location=file:./application-postgres.properties
+   ```
+
+---
+
+### **Problem: "Database connection failed"**
+
+**Solution:**
+1. Verify KIND cluster is running:
+   ```bash
+   kubectl get nodes
+   ```
+
+2. Verify PostgreSQL pod is running:
+   ```bash
+   kubectl get pod -n monthly-expense monthly-expense-postgresql-0
+   ```
+
+3. Test PostgreSQL connection:
+   ```bash
+   kubectl exec -n monthly-expense monthly-expense-postgresql-0 -- \
+     env PGPASSWORD='4bTp9VmJ0D%' psql -U postgres -d monthly_expense_db -c "\dt"
+   ```
+
+---
+
+## 📝 **Example Conversation Flow**
+
+Here's a complete example of what you can do:
+
+**You:** "Hi Claude, I want to analyze my expenses"
+
+**Claude:** "I'd be happy to help! I have access to your expense data through the monthly-expenses MCP server. What would you like to know?"
+
+**You:** "What's my total spending and which category am I spending the most on?"
+
+**Claude:** *[Calls get_total_spending and get_category_totals]*
+
+"Based on your expense data:
+- **Total Spending:** $8,724.88 across 119 transactions
+- **Average Transaction:** $73.32
+
+**Top Spending Categories:**
+1. 🏠 Rent: $3,780.00 (43% of total)
+2. 👶 Day Care: $894.50 (10%)
+3. 🛒 Groceries: $873.80 (10%)
+4. 🛍️ Shopping: $867.53 (10%)
+5. 🍽️ Eating Out: $750.80 (9%)
+
+Your rent is by far your largest expense, accounting for nearly half of your total spending."
+
+**You:** "Can you find all my grocery transactions?"
+
+**Claude:** *[Calls query_expenses with category="Groceries"]*
+
+"I found X grocery transactions totaling $873.80. Here are the details..."
+
+---
+
+## 🎯 **Advanced Queries to Try**
+
+Once the basic tests work, try these:
+
+1. **Trend Analysis:**
+   - "How does my December spending compare to other months?"
+   - "What's my average monthly spending?"
+
+2. **Budget Insights:**
+   - "Which categories could I reduce spending on?"
+   - "Show me all transactions over $200"
+
+3. **Search & Filter:**
+   - "Find all transactions at Coles or Woolworths"
+   - "Show me all eating out expenses in December"
+
+4. **Statistical Analysis:**
+   - "What's the largest single transaction I made?"
+   - "How many transactions do I make per month on average?"
+
+---
+
+## 📊 **Available MCP Tools**
+
+Claude has access to these 6 tools:
+
+1. **query_expenses** - Search/filter transactions by date, category, amount
+2. **get_category_totals** - Spending breakdown by category
+3. **get_monthly_summary** - Monthly spending for a specific year
+4. **get_total_spending** - Overall spending statistics
+5. **search_transactions** - Full-text search on descriptions
+6. **get_primary_currency** - Get currency code
+
+---
+
+## 🔧 **Manual Testing (Without Claude Desktop)**
+
+If you want to test the tools directly:
+
+```bash
+# Test via HTTP API
+curl -X POST http://localhost:8082/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "tools/call",
+    "params": {
+      "name": "get_total_spending",
+      "arguments": {}
+    }
+  }' | jq
+```
+
+---
+
+## ✅ **Success Indicators**
+
+You'll know it's working when:
+- ✅ Claude mentions using the "monthly-expenses" tool
+- ✅ Claude returns actual numbers from your database
+- ✅ Claude can answer follow-up questions using the data
+- ✅ You see tool calls in real-time (MCP indicator shows activity)
+
+---
+
+## 📚 **Next Steps**
+
+After successful testing:
+1. ✅ Explore natural language queries with your expense data
+2. ✅ Ask Claude for spending insights and recommendations
+3. ✅ Use Claude to find patterns in your spending
+4. ✅ Get budget recommendations based on your data
+
+---
+
+## 🎉 **You're All Set!**
+
+Your MCP server is configured and ready to use with Claude Desktop. Restart Claude Desktop and start asking questions about your expenses!

--- a/mcp-server/KIND_SETUP.md
+++ b/mcp-server/KIND_SETUP.md
@@ -1,0 +1,291 @@
+# MCP Server with KIND PostgreSQL - Complete Setup Guide
+
+## 🎯 Overview
+
+Your MCP server is now fully integrated with the PostgreSQL database running in your KIND (Kubernetes IN Docker) cluster!
+
+---
+
+## ✅ What's Configured
+
+### **Database Connection:**
+- **KIND PostgreSQL Service:** `monthly-expense-postgresql` (namespace: `monthly-expense`)
+- **Database Name:** `monthly_expense_db`
+- **Username:** `postgres`
+- **Password:** `4bTp9VmJ0D%` (from Kubernetes secret)
+- **Connection Method:** Port-forward from KIND to localhost:5432
+
+### **MCP Server:**
+- **Port:** 8082
+- **WebSocket Endpoint:** `ws://localhost:8082/mcp`
+- **HTTP Endpoint:** `POST http://localhost:8082/api/mcp`
+- **Health Check:** `http://localhost:8082/actuator/health`
+
+### **Registered MCP Tools (6):**
+1. `query_expenses` - Search/filter transactions
+2. `get_category_totals` - Spending by category
+3. `get_monthly_summary` - Monthly breakdown
+4. `get_total_spending` - Overall statistics
+5. `search_transactions` - Full-text search
+6. `get_primary_currency` - Get currency code
+
+---
+
+## 🚀 Quick Start
+
+### **Start Everything:**
+```bash
+cd /Users/sandeepkamath/sandeep/MonthlyExpense/mcp-server
+./start-mcp-kind.sh
+```
+
+### **Stop Everything:**
+```bash
+./stop-mcp-kind.sh
+```
+
+### **Check Status:**
+```bash
+# Check if MCP server is running
+curl http://localhost:8082/actuator/health
+
+# Check if port-forward is active
+lsof -i :5432
+
+# View MCP server logs
+tail -f /tmp/mcp-server.log
+
+# View PostgreSQL port-forward logs
+tail -f /tmp/postgres-port-forward.log
+```
+
+---
+
+## 📝 Manual Startup (Alternative)
+
+If you want to start components individually:
+
+### **1. Start PostgreSQL Port-Forward:**
+```bash
+kubectl port-forward -n monthly-expense service/monthly-expense-postgresql 5432:5432 &
+```
+
+### **2. Start MCP Server:**
+```bash
+cd /Users/sandeepkamath/sandeep/MonthlyExpense/mcp-server
+java -jar target/mcp-server-1.0.0.jar \
+  --spring.config.location=file:./application-postgres.properties &
+```
+
+---
+
+## 🧪 Testing the MCP Server
+
+### **Test 1: List Available Tools**
+```bash
+curl -X POST http://localhost:8082/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "tools/list",
+    "params": {}
+  }' | jq
+```
+
+### **Test 2: Get Total Spending**
+```bash
+curl -X POST http://localhost:8082/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "tools/call",
+    "params": {
+      "name": "get_total_spending",
+      "arguments": {}
+    }
+  }' | jq
+```
+
+### **Test 3: Query Expenses by Category**
+```bash
+curl -X POST http://localhost:8082/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "3",
+    "method": "tools/call",
+    "params": {
+      "name": "query_expenses",
+      "arguments": {
+        "category": "Groceries"
+      }
+    }
+  }' | jq
+```
+
+### **Test 4: Get Category Totals**
+```bash
+curl -X POST http://localhost:8082/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "4",
+    "method": "tools/call",
+    "params": {
+      "name": "get_category_totals",
+      "arguments": {}
+    }
+  }' | jq
+```
+
+---
+
+## 💬 Using with Claude Desktop
+
+### **Configuration:**
+
+Edit your Claude Desktop config file:
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add this configuration:
+```json
+{
+  "mcpServers": {
+    "monthly-expenses": {
+      "url": "ws://localhost:8082/mcp"
+    }
+  }
+}
+```
+
+### **Usage Examples:**
+
+Once configured, you can ask Claude:
+
+- "What did I spend on groceries last month?"
+- "Show me all transactions over $100"
+- "What's my total spending?"
+- "Which category do I spend the most on?"
+- "Find all transactions at Woolworths"
+- "What's my average transaction amount?"
+
+---
+
+## 📂 File Structure
+
+```
+mcp-server/
+├── target/mcp-server-1.0.0.jar          # Compiled MCP server
+├── application-postgres.properties       # PostgreSQL configuration
+├── start-mcp-kind.sh                    # Start script
+├── stop-mcp-kind.sh                     # Stop script
+├── README.md                            # Main documentation
+├── USAGE_GUIDE.md                       # Detailed usage guide
+└── KIND_SETUP.md                        # This file
+```
+
+---
+
+## 🔧 Troubleshooting
+
+### **Port 5432 already in use:**
+```bash
+# Check what's using port 5432
+lsof -i :5432
+
+# Kill existing port-forward
+pkill -f 'port-forward.*postgresql'
+
+# Restart port-forward
+kubectl port-forward -n monthly-expense service/monthly-expense-postgresql 5432:5432 &
+```
+
+### **Port 8082 already in use:**
+```bash
+# Check what's using port 8082
+lsof -i :8082
+
+# Kill existing MCP server
+pkill -f 'mcp-server-1.0.0.jar'
+
+# Restart MCP server
+./start-mcp-kind.sh
+```
+
+### **KIND cluster not accessible:**
+```bash
+# Check Docker Desktop is running
+docker ps
+
+# Check kubectl can connect
+kubectl get nodes
+
+# Check PostgreSQL pod is running
+kubectl get pod -n monthly-expense monthly-expense-postgresql-0
+```
+
+### **MCP server can't connect to PostgreSQL:**
+```bash
+# Verify port-forward is active
+lsof -i :5432
+
+# Test PostgreSQL connection from kubectl
+kubectl exec -n monthly-expense monthly-expense-postgresql-0 -- env PGPASSWORD='4bTp9VmJ0D%' psql -U postgres -d monthly_expense_db -c "\dt"
+
+# Check MCP server logs
+tail -100 /tmp/mcp-server.log
+```
+
+---
+
+## 📊 Current Database Statistics
+
+From your KIND PostgreSQL database:
+- **Total Spending:** $8,724.88
+- **Total Transactions:** 119
+- **Average Transaction:** $73.32
+- **Categories:** 16
+
+**Top Spending Categories:**
+1. Rent: $3,780.00
+2. Day Care: $894.50
+3. Groceries: $873.80
+4. Shopping: $867.53
+5. Eating Out: $750.80
+
+---
+
+## 🔐 Security Notes
+
+- PostgreSQL password is stored in Kubernetes secret
+- MCP server authentication is disabled (set `mcp.server.auth.enabled=true` for production)
+- Port-forward is only accessible from localhost
+- KIND cluster is isolated within Docker Desktop
+
+---
+
+## 📚 Additional Resources
+
+- **MCP Specification:** https://spec.modelcontextprotocol.io/
+- **Spring Boot Docs:** https://docs.spring.io/spring-boot/docs/current/reference/
+- **KIND Documentation:** https://kind.sigs.k8s.io/
+- **PostgreSQL Docs:** https://www.postgresql.org/docs/
+
+---
+
+## ✅ Next Steps
+
+1. ✅ **Done:** MCP server connected to KIND PostgreSQL
+2. ✅ **Done:** All 6 tools working and tested
+3. **Optional:** Configure Claude Desktop to use the MCP server
+4. **Optional:** Add more custom MCP tools (see USAGE_GUIDE.md)
+5. **Optional:** Enable API key authentication for production
+
+---
+
+**Questions or Issues?** Check the logs:
+- MCP Server: `/tmp/mcp-server.log`
+- PostgreSQL Port-Forward: `/tmp/postgres-port-forward.log`

--- a/mcp-server/QUICK_START.md
+++ b/mcp-server/QUICK_START.md
@@ -1,0 +1,158 @@
+# 🚀 Quick Start Guide - Claude Desktop MCP Integration
+
+## ✅ **Configuration Status**
+
+### **What's Ready:**
+- ✅ MCP server built and configured
+- ✅ PostgreSQL connection to KIND cluster configured
+- ✅ Claude Desktop config file updated
+- ✅ PostgreSQL port-forward running
+- ✅ 6 expense analysis tools available
+
+---
+
+## 🎯 **Quick Start (3 Steps)**
+
+### **1. Ensure Prerequisites are Running**
+
+```bash
+# Start PostgreSQL port-forward (if not already running)
+kubectl port-forward -n monthly-expense service/monthly-expense-postgresql 5432:5432 &
+
+# Verify it's running
+lsof -i :5432
+```
+
+### **2. Restart Claude Desktop**
+
+- **Quit:** `Cmd + Q`
+- **Reopen:** Claude Desktop will auto-start the MCP server
+- **Wait:** ~30 seconds for initialization
+
+### **3. Test with a Simple Question**
+
+Open Claude Desktop and ask:
+```
+What's my total spending?
+```
+
+**Expected:** Claude calls the tool and shows $8,724.88 total
+
+---
+
+## 📝 **Quick Test Questions**
+
+Copy and paste these into Claude Desktop:
+
+```
+1. What's my total spending?
+
+2. Show me my spending by category
+
+3. How much did I spend on groceries?
+
+4. Find all transactions at Woolworths
+
+5. What's my largest expense?
+
+6. Show me December spending
+```
+
+---
+
+## 🔍 **Verify MCP is Connected**
+
+Look for indicators in Claude Desktop:
+- **Bottom right:** Server connection status (click to see "monthly-expenses")
+- **Tool usage:** Claude mentions using your expense tools
+- **Real data:** Actual dollar amounts from your database
+
+---
+
+## 🐛 **Quick Troubleshooting**
+
+### **Issue: MCP server not connecting**
+```bash
+# Check if port-forward is running
+lsof -i :5432
+
+# If not, restart it
+kubectl port-forward -n monthly-expense service/monthly-expense-postgresql 5432:5432 &
+
+# Restart Claude Desktop
+```
+
+### **Issue: Can't see monthly-expenses server**
+```bash
+# Verify config file
+cat ~/Library/Application\ Support/Claude/claude_desktop_config.json | jq
+
+# Check Claude logs
+tail -100 ~/Library/Logs/Claude/mcp*.log
+```
+
+---
+
+## 📂 **Important Files**
+
+- **Config:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **MCP Server:** `/Users/sandeepkamath/sandeep/MonthlyExpense/mcp-server/`
+- **Test Guide:** `CLAUDE_DESKTOP_TEST.md` (detailed testing)
+- **KIND Setup:** `KIND_SETUP.md` (manual setup)
+
+---
+
+## 🎯 **Current Database Stats**
+
+Your KIND PostgreSQL contains:
+- **Total:** $8,724.88
+- **Transactions:** 119
+- **Categories:** 16
+- **Top Category:** Rent ($3,780.00)
+
+---
+
+## 💡 **What You Can Do**
+
+Ask Claude natural questions like:
+- "What did I spend on X last month?"
+- "Show me my top 5 spending categories"
+- "Find all transactions over $100"
+- "How does my December spending compare to November?"
+- "Which categories could I reduce?"
+- "What's my average transaction amount?"
+
+Claude will automatically call the right MCP tools to answer!
+
+---
+
+## 🔄 **Daily Usage**
+
+### **Start of Day:**
+```bash
+# Ensure PostgreSQL port-forward is running
+lsof -i :5432 || kubectl port-forward -n monthly-expense service/monthly-expense-postgresql 5432:5432 &
+```
+
+### **Use Claude Desktop:**
+Just ask questions - MCP server starts automatically!
+
+### **End of Day:**
+No cleanup needed - everything stops when you quit Claude Desktop
+
+---
+
+## 📞 **Need Help?**
+
+- **Detailed Testing:** See `CLAUDE_DESKTOP_TEST.md`
+- **KIND Setup:** See `KIND_SETUP.md`
+- **Usage Examples:** See `USAGE_GUIDE.md`
+- **Technical Docs:** See `README.md`
+
+---
+
+## ✅ **Ready to Test!**
+
+**Next Step:** Restart Claude Desktop and ask "What's my total spending?"
+
+Your MCP server will automatically connect and provide real data! 🎉

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,301 @@
+# Monthly Expense Tracker - MCP Server
+
+## Overview
+
+This is an **MCP (Model Context Protocol) server** for the Monthly Expense Tracker application. It allows AI assistants like Claude to interact with your expense data using natural language queries and analysis tools.
+
+### What is MCP?
+
+MCP (Model Context Protocol) is a standardized protocol that allows AI models to:
+- Call functions/tools in your application
+- Query databases and APIs
+- Perform complex analysis
+- All through natural language interaction!
+
+### Architecture
+
+```
+┌─────────────┐          ┌──────────────────┐          ┌────────────────┐
+│   Claude    │ ◄────────┤   MCP Server     │◄─────────┤ TransactionService │
+│ (AI Client) │  WebSocket  │  (This Module)   │  Reuses  │  (Backend Module)  │
+│             │   or HTTP   │                  │          │                    │
+└─────────────┘          └──────────────────┘          └────────────────┘
+                                   │
+                                   ▼
+                          ┌─────────────────┐
+                          │   PostgreSQL    │
+                          │   Database      │
+                          └─────────────────┘
+```
+
+## Features
+
+### 🔧 MCP Framework
+- **Annotation-based tool definition** - Just annotate methods with `@McpTool`
+- **Automatic tool discovery** - No manual registration needed
+- **Type-safe parameters** - Leverages Java's type system
+- **JSON-RPC 2.0 protocol** - Industry standard RPC over JSON
+- **Dual transport** - WebSocket + HTTP endpoints
+
+### 📊 Available Tools
+
+1. **query_expenses** - Search expenses by date, category, amount, description
+2. **get_category_totals** - Spending breakdown by category
+3. **get_monthly_summary** - Monthly spending for a specific year
+4. **get_total_spending** - Overall spending statistics
+5. **search_transactions** - Full-text search on descriptions
+6. **get_primary_currency** - Get the currency used in the database
+
+## Quick Start
+
+### Prerequisites
+
+- Java 11 or higher
+- Maven 3.6+
+- Backend module (`backend/`) built and available
+
+### Build
+
+```bash
+# From mcp-server directory
+mvn clean package
+
+# Or build both backend and mcp-server
+cd /Users/sandeepkamath/sandeep/MonthlyExpense
+mvn -f backend/pom.xml clean install
+mvn -f mcp-server/pom.xml clean package
+```
+
+### Run
+
+```bash
+# From mcp-server directory
+mvn spring-boot:run
+
+# Or run the JAR
+java -jar target/mcp-server-1.0.0.jar
+```
+
+The MCP server will start on port **8082** by default.
+
+**Endpoints:**
+- WebSocket: `ws://localhost:8082/mcp`
+- HTTP: `POST http://localhost:8082/api/mcp`
+- Health: `GET http://localhost:8082/api/mcp/health`
+
+## Configuration
+
+Edit `src/main/resources/application.yml`:
+
+```yaml
+mcp:
+  server:
+    enabled: true
+
+    websocket:
+      path: /mcp
+      enabled: true
+
+    http:
+      enabled: true
+      path: /api/mcp
+
+    auth:
+      enabled: false  # Set to true for production
+      api-keys:
+        - "your-secret-api-key-here"
+```
+
+### Database Configuration
+
+By default, uses H2 in-memory database. For PostgreSQL:
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/monthly_expense_db
+    username: your_username
+    password: your_password
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+```
+
+## Usage Examples
+
+### HTTP Testing with curl
+
+**List available tools:**
+
+```bash
+curl -X POST http://localhost:8082/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "tools/list",
+    "params": {}
+  }'
+```
+
+**Query expenses for groceries:**
+
+```bash
+curl -X POST http://localhost:8082/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "tools/call",
+    "params": {
+      "name": "query_expenses",
+      "arguments": {
+        "category": "Groceries",
+        "month": 12,
+        "year": 2025
+      }
+    }
+  }'
+```
+
+**Get category totals:**
+
+```bash
+curl -X POST http://localhost:8082/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "3",
+    "method": "tools/call",
+    "params": {
+      "name": "get_category_totals",
+      "arguments": {
+        "month": 12,
+        "year": 2025
+      }
+    }
+  }'
+```
+
+### Using with Claude Desktop
+
+1. Install Claude Desktop app
+2. Configure MCP server in Claude's settings:
+
+```json
+{
+  "mcpServers": {
+    "monthly-expenses": {
+      "url": "ws://localhost:8082/mcp"
+    }
+  }
+}
+```
+
+3. Ask Claude questions:
+   - "What did I spend on groceries last month?"
+   - "Show me all transactions over $100"
+   - "What's my total spending for 2025?"
+
+## Development
+
+### Adding New Tools
+
+1. Create a method in `ExpenseTools.java` (or a new `@McpResource` class)
+2. Annotate with `@McpTool`:
+
+```java
+@McpTool(
+    name = "my_new_tool",
+    description = "What this tool does"
+)
+public Map<String, Object> myNewTool(
+    @McpParam(name = "param1", required = true, description = "First parameter")
+    String param1
+) {
+    // Implementation
+    return Map.of("result", "value");
+}
+```
+
+3. Restart the server - tool is automatically discovered!
+
+### Project Structure
+
+```
+mcp-server/
+├── src/main/java/com/expense/mcp/
+│   ├── McpServerApplication.java      # Main application
+│   ├── annotations/                    # @McpTool, @McpParam, @McpResource
+│   ├── core/                          # Tool registry, executor, converter
+│   ├── protocol/                      # JSON-RPC 2.0 models
+│   ├── transport/                     # WebSocket + HTTP handlers
+│   ├── security/                      # API key authentication
+│   ├── config/                        # Spring configuration
+│   └── tools/                         # Expense-specific tools
+└── src/main/resources/
+    └── application.yml                # Configuration
+```
+
+## Testing
+
+```bash
+# Run all tests
+mvn test
+
+# Run specific test
+mvn test -Dtest=McpToolRegistryTest
+```
+
+## Security
+
+### API Key Authentication
+
+Enable in production:
+
+```yaml
+mcp:
+  server:
+    auth:
+      enabled: true
+      api-keys:
+        - "your-secret-key-1"
+        - "your-secret-key-2"
+```
+
+Then include the API key in requests:
+
+```bash
+curl -X POST http://localhost:8082/api/mcp \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-API-Key: your-secret-key-1" \
+  -d '...'
+```
+
+## Troubleshooting
+
+**Port 8082 already in use:**
+```yaml
+server:
+  port: 8083  # Change port
+```
+
+**Cannot find backend classes:**
+- Ensure backend module is built: `mvn -f backend/pom.xml install`
+- Check dependency version in `pom.xml` matches backend version
+
+**Tools not discovered:**
+- Check that `@McpResource` class is in `com.expense.mcp.tools` package
+- Verify Spring component scanning is enabled
+- Check logs for registration messages
+
+## License
+
+Same as parent project.
+
+## Support
+
+For issues or questions, please file an issue in the main repository.

--- a/mcp-server/USAGE_GUIDE.md
+++ b/mcp-server/USAGE_GUIDE.md
@@ -1,0 +1,455 @@
+# MCP Server Usage Guide
+
+## 🎯 Quick Start Guide
+
+### Step 1: Build and Run
+
+```bash
+# From project root
+cd /Users/sandeepkamath/sandeep/MonthlyExpense
+
+# Build both modules
+mvn -f backend/pom.xml clean install -DskipTests
+mvn -f mcp-server/pom.xml clean package -DskipTests
+
+# Run MCP server
+cd mcp-server
+mvn spring-boot:run
+```
+
+**Server URLs:**
+- WebSocket: `ws://localhost:8082/mcp`
+- HTTP: `http://localhost:8082/api/mcp`
+- Health: `http://localhost:8082/actuator/health`
+
+### Step 2: Test the Server
+
+**Test 1: List Available Tools**
+
+```bash
+curl -X POST http://localhost:8082/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "tools/list",
+    "params": {}
+  }' | jq
+```
+
+Expected response:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": {
+    "tools": [
+      {
+        "name": "query_expenses",
+        "description": "Query expenses by date range, category, description, or amount range...",
+        "inputSchema": { ... }
+      },
+      ...
+    ]
+  }
+}
+```
+
+**Test 2: Query Expenses**
+
+```bash
+curl -X POST http://localhost:8082/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "tools/call",
+    "params": {
+      "name": "query_expenses",
+      "arguments": {
+        "category": "Groceries"
+      }
+    }
+  }' | jq
+```
+
+**Test 3: Get Category Totals**
+
+```bash
+curl -X POST http://localhost:8082/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "3",
+    "method": "tools/call",
+    "params": {
+      "name": "get_category_totals",
+      "arguments": {}
+    }
+  }' | jq
+```
+
+## 📊 Available Tools Reference
+
+### 1. query_expenses
+
+Search and filter transactions.
+
+**Parameters:**
+- `startDate` (optional): Start date in YYYY-MM-DD format
+- `endDate` (optional): End date in YYYY-MM-DD format
+- `category` (optional): Category name (e.g., "Groceries")
+- `description` (optional): Search text in description
+- `minAmount` (optional): Minimum amount
+- `maxAmount` (optional): Maximum amount
+- `month` (optional): Month (1-12)
+- `year` (optional): Year
+
+**Example:**
+```json
+{
+  "name": "query_expenses",
+  "arguments": {
+    "category": "Groceries",
+    "month": 12,
+    "year": 2025,
+    "minAmount": 50
+  }
+}
+```
+
+### 2. get_category_totals
+
+Get spending totals grouped by category.
+
+**Parameters:**
+- `month` (optional): Month (1-12)
+- `year` (optional): Year
+
+**Example:**
+```json
+{
+  "name": "get_category_totals",
+  "arguments": {
+    "month": 12,
+    "year": 2025
+  }
+}
+```
+
+### 3. get_monthly_summary
+
+Get monthly breakdown for a specific year.
+
+**Parameters:**
+- `year` (required): Year to analyze
+
+**Example:**
+```json
+{
+  "name": "get_monthly_summary",
+  "arguments": {
+    "year": 2025
+  }
+}
+```
+
+### 4. get_total_spending
+
+Get overall spending statistics.
+
+**Parameters:** None
+
+**Example:**
+```json
+{
+  "name": "get_total_spending",
+  "arguments": {}
+}
+```
+
+### 5. search_transactions
+
+Full-text search on transaction descriptions.
+
+**Parameters:**
+- `searchText` (required): Text to search for
+
+**Example:**
+```json
+{
+  "name": "search_transactions",
+  "arguments": {
+    "searchText": "coffee"
+  }
+}
+```
+
+### 6. get_primary_currency
+
+Get the primary currency code.
+
+**Parameters:** None
+
+**Example:**
+```json
+{
+  "name": "get_primary_currency",
+  "arguments": {}
+}
+```
+
+## 🤖 Using with Claude Desktop
+
+### 1. Install Claude Desktop
+
+Download from: https://claude.ai/download
+
+### 2. Configure MCP Server
+
+Edit Claude Desktop's config file:
+
+**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add this configuration:
+
+```json
+{
+  "mcpServers": {
+    "monthly-expenses": {
+      "command": "java",
+      "args": [
+        "-jar",
+        "/Users/sandeepkamath/sandeep/MonthlyExpense/mcp-server/target/mcp-server-1.0.0.jar"
+      ],
+      "env": {
+        "DATABASE_URL": "jdbc:postgresql://localhost:5432/monthly_expense_db",
+        "DATABASE_USER": "your_username",
+        "DATABASE_PASSWORD": "your_password"
+      }
+    }
+  }
+}
+```
+
+### 3. Restart Claude Desktop
+
+Close and reopen Claude Desktop. The MCP server should start automatically.
+
+### 4. Interact with Your Expenses
+
+Now you can ask Claude natural language questions:
+
+- "What did I spend on groceries last month?"
+- "Show me all transactions over $100 in December"
+- "What's my total spending for 2025?"
+- "Which category do I spend the most on?"
+- "Find all transactions containing 'Starbucks'"
+
+## 🔒 Security Configuration
+
+### Enable API Key Authentication
+
+1. Edit `application.yml`:
+
+```yaml
+mcp:
+  server:
+    auth:
+      enabled: true
+      api-keys:
+        - "your-secret-api-key-here"
+        - "another-api-key"
+```
+
+2. Restart server
+
+3. Include API key in requests:
+
+```bash
+curl -X POST http://localhost:8082/api/mcp \
+  -H "Content-Type: application/json" \
+  -H "X-MCP-API-Key: your-secret-api-key-here" \
+  -d '{...}'
+```
+
+## 🗄️ Database Configuration
+
+### Using PostgreSQL (Production)
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/monthly_expense_db
+    username: postgres
+    password: your_password
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+```
+
+### Using H2 (Development)
+
+Default configuration (no changes needed):
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:h2:file:./data/expense_db
+    username: sa
+    password: password
+```
+
+## 🐛 Troubleshooting
+
+### Server won't start
+
+**Check port availability:**
+```bash
+lsof -i :8082
+```
+
+If port is in use, change it in `application.yml`:
+```yaml
+server:
+  port: 8083
+```
+
+### Tools not discovered
+
+Check logs for:
+```
+Registered tool: query_expenses
+Registered tool: get_category_totals
+...
+```
+
+If tools aren't showing, verify `ExpenseTools.java` has `@McpResource` annotation.
+
+### Database connection error
+
+Verify database is running:
+```bash
+# PostgreSQL
+psql -h localhost -U postgres -d monthly_expense_db
+
+# H2
+# Check console at http://localhost:8082/h2-console
+```
+
+### API key authentication failing
+
+Check header name matches configuration:
+```yaml
+mcp:
+  server:
+    auth:
+      header-name: X-MCP-API-Key  # Default
+```
+
+## 📝 Adding Custom Tools
+
+### Example: Add a "get_expensive_transactions" tool
+
+1. Open `ExpenseTools.java`
+
+2. Add new method:
+
+```java
+@McpTool(
+    name = "get_expensive_transactions",
+    description = "Get transactions above a certain amount threshold"
+)
+public Map<String, Object> getExpensiveTransactions(
+    @McpParam(
+        name = "threshold",
+        description = "Minimum amount to consider expensive",
+        required = true
+    ) BigDecimal threshold,
+
+    @McpParam(
+        name = "limit",
+        description = "Maximum number of results to return",
+        required = false,
+        defaultValue = "10"
+    ) Integer limit
+) {
+    List<Transaction> transactions = transactionService.getAllTransactions()
+        .stream()
+        .filter(t -> t.getAmount().compareTo(threshold) >= 0)
+        .sorted((t1, t2) -> t2.getAmount().compareTo(t1.getAmount()))
+        .limit(limit)
+        .collect(Collectors.toList());
+
+    BigDecimal total = transactions.stream()
+        .map(Transaction::getAmount)
+        .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+    return Map.of(
+        "count", transactions.size(),
+        "total", total,
+        "threshold", threshold,
+        "transactions", transactions
+    );
+}
+```
+
+3. Rebuild and restart:
+
+```bash
+mvn clean package -DskipTests
+mvn spring-boot:run
+```
+
+4. Test new tool:
+
+```bash
+curl -X POST http://localhost:8082/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "tools/call",
+    "params": {
+      "name": "get_expensive_transactions",
+      "arguments": {
+        "threshold": 100,
+        "limit": 5
+      }
+    }
+  }' | jq
+```
+
+That's it! The tool is automatically discovered and registered.
+
+## 🚀 Performance Tips
+
+1. **Enable JPA query caching** for frequently accessed data
+2. **Add database indexes** on commonly queried fields
+3. **Use connection pooling** for production PostgreSQL
+4. **Limit result sizes** with pagination parameters
+5. **Enable HTTP compression** for large responses
+
+## 📦 Deployment
+
+See the main README for Docker and Kubernetes deployment instructions.
+
+## 💡 Best Practices
+
+1. **Always validate input parameters** using `@McpParam` constraints
+2. **Return structured data** (Maps/Objects) not just strings
+3. **Include counts and totals** in query results
+4. **Log tool executions** for debugging
+5. **Handle exceptions gracefully** and return meaningful errors
+6. **Document tool descriptions** clearly for Claude to understand when to use them
+7. **Use semantic tool names** (e.g., `get_monthly_summary` not `monthlySum`)
+
+## 📚 Additional Resources
+
+- [MCP Specification](https://spec.modelcontextprotocol.io/)
+- [Claude Desktop Docs](https://docs.anthropic.com/claude/docs)
+- [Spring Boot Reference](https://docs.spring.io/spring-boot/docs/current/reference/)

--- a/mcp-server/application-postgres.properties
+++ b/mcp-server/application-postgres.properties
@@ -1,0 +1,35 @@
+# PostgreSQL Configuration for KIND cluster
+server.port=8082
+
+# PostgreSQL Database
+spring.datasource.url=jdbc:postgresql://localhost:5432/monthly_expense_db
+spring.datasource.username=postgres
+spring.datasource.password=4bTp9VmJ0D%
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# HikariCP
+spring.datasource.hikari.minimum-idle=5
+spring.datasource.hikari.maximum-pool-size=10
+
+# JPA/Hibernate
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+
+# Disable H2
+spring.h2.console.enabled=false
+
+# MCP Server
+mcp.server.enabled=true
+mcp.server.websocket.enabled=true
+mcp.server.websocket.path=/mcp
+mcp.server.http.enabled=true
+mcp.server.http.path=/api/mcp
+
+# Logging
+logging.level.root=INFO
+logging.level.com.expense.mcp=DEBUG
+logging.level.com.expense.monthly=INFO
+logging.level.org.hibernate.SQL=DEBUG

--- a/mcp-server/build.sh
+++ b/mcp-server/build.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+#
+# Build script for MCP Server
+# Builds both backend and mcp-server modules
+#
+
+set -e  # Exit on error
+
+echo "========================================="
+echo "Building Monthly Expense MCP Server"
+echo "========================================="
+echo ""
+
+# Get the project root directory
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+echo "Project root: $PROJECT_ROOT"
+echo ""
+
+# Step 1: Build backend module
+echo "Step 1/2: Building backend module..."
+echo "-----------------------------------"
+cd "$PROJECT_ROOT/backend"
+mvn clean install -DskipTests
+echo "✓ Backend build successful"
+echo ""
+
+# Step 2: Build MCP server
+echo "Step 2/2: Building MCP server..."
+echo "-----------------------------------"
+cd "$PROJECT_ROOT/mcp-server"
+mvn clean package -DskipTests
+echo "✓ MCP server build successful"
+echo ""
+
+# Display build artifacts
+echo "========================================="
+echo "Build Complete!"
+echo "========================================="
+echo ""
+echo "Artifacts created:"
+echo "  Backend JAR:     $PROJECT_ROOT/backend/target/monthly-1.2.0.jar"
+echo "  MCP Server JAR:  $PROJECT_ROOT/mcp-server/target/mcp-server-1.0.0.jar"
+echo ""
+echo "To run the MCP server:"
+echo "  cd $PROJECT_ROOT/mcp-server"
+echo "  java -jar target/mcp-server-1.0.0.jar"
+echo ""
+echo "Or use Maven:"
+echo "  cd $PROJECT_ROOT/mcp-server"
+echo "  mvn spring-boot:run"
+echo ""
+echo "MCP Server will be available at:"
+echo "  WebSocket: ws://localhost:8082/mcp"
+echo "  HTTP:      http://localhost:8082/api/mcp"
+echo "========================================="

--- a/mcp-server/pom.xml
+++ b/mcp-server/pom.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.14</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.expense</groupId>
+    <artifactId>mcp-server</artifactId>
+    <version>1.0.0</version>
+    <name>MCP Server for Monthly Expense Tracker</name>
+    <description>Model Context Protocol server for AI-assisted expense analysis</description>
+
+    <properties>
+        <java.version>11</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <reflections.version>0.10.2</reflections.version>
+    </properties>
+
+    <dependencies>
+        <!-- Spring Boot Starters -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- Backend Module Dependency - Reuse all existing services -->
+        <dependency>
+            <groupId>com.expense</groupId>
+            <artifactId>monthly</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+
+        <!-- Reflections for annotation scanning -->
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>${reflections.version}</version>
+        </dependency>
+
+        <!-- Jackson for JSON serialization -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <!-- Lombok for reducing boilerplate -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Database (inherited from backend) -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.3</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Actuator for health checks -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/mcp-server/setup-postgres.sh
+++ b/mcp-server/setup-postgres.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+#
+# PostgreSQL Setup Script for MCP Server
+# Creates the database and user if they don't exist
+#
+
+set -e
+
+echo "========================================="
+echo "PostgreSQL Setup for MCP Server"
+echo "========================================="
+echo ""
+
+# Configuration
+DB_NAME="monthly_expense_db"
+DB_USER="postgres"
+DB_HOST="localhost"
+DB_PORT="5432"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Check if PostgreSQL is running
+echo "Checking PostgreSQL connection..."
+if psql -h $DB_HOST -p $DB_PORT -U $DB_USER -lqt 2>/dev/null | cut -d \| -f 1 | grep -qw template1; then
+    echo -e "${GREEN}✓ PostgreSQL is running${NC}"
+else
+    echo -e "${RED}✗ PostgreSQL is not running or not accessible${NC}"
+    echo ""
+    echo "Please start PostgreSQL first:"
+    echo "  macOS (Homebrew): brew services start postgresql@14"
+    echo "  macOS (Postgres.app): Open Postgres.app"
+    echo "  Docker: docker-compose up -d"
+    echo ""
+    exit 1
+fi
+
+# Check if database exists
+echo ""
+echo "Checking if database '$DB_NAME' exists..."
+if psql -h $DB_HOST -p $DB_PORT -U $DB_USER -lqt | cut -d \| -f 1 | grep -qw $DB_NAME; then
+    echo -e "${YELLOW}⚠ Database '$DB_NAME' already exists${NC}"
+    echo ""
+    read -p "Do you want to drop and recreate it? (y/N): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        echo "Dropping database '$DB_NAME'..."
+        psql -h $DB_HOST -p $DB_PORT -U $DB_USER -c "DROP DATABASE IF EXISTS $DB_NAME;"
+        echo -e "${GREEN}✓ Database dropped${NC}"
+    else
+        echo "Keeping existing database."
+        echo ""
+        echo -e "${GREEN}✓ Setup complete - using existing database${NC}"
+        exit 0
+    fi
+fi
+
+# Create database
+echo ""
+echo "Creating database '$DB_NAME'..."
+psql -h $DB_HOST -p $DB_PORT -U $DB_USER -c "CREATE DATABASE $DB_NAME;"
+echo -e "${GREEN}✓ Database '$DB_NAME' created successfully${NC}"
+
+# Grant privileges (if needed)
+echo ""
+echo "Setting up permissions..."
+psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_NAME -c "GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USER;"
+echo -e "${GREEN}✓ Permissions configured${NC}"
+
+echo ""
+echo "========================================="
+echo -e "${GREEN}PostgreSQL Setup Complete!${NC}"
+echo "========================================="
+echo ""
+echo "Database Details:"
+echo "  Host:     $DB_HOST"
+echo "  Port:     $DB_PORT"
+echo "  Database: $DB_NAME"
+echo "  Username: $DB_USER"
+echo ""
+echo "Connection String:"
+echo "  jdbc:postgresql://$DB_HOST:$DB_PORT/$DB_NAME"
+echo ""
+echo "Next Steps:"
+echo "  1. Start MCP Server: mvn spring-boot:run"
+echo "  2. Or run JAR: java -jar target/mcp-server-1.0.0.jar"
+echo ""
+echo "The database schema will be created automatically when the MCP server starts."
+echo "========================================="

--- a/mcp-server/src/main/java/com/expense/mcp/McpServerApplication.java
+++ b/mcp-server/src/main/java/com/expense/mcp/McpServerApplication.java
@@ -1,0 +1,193 @@
+package com.expense.mcp;
+
+import com.expense.mcp.transport.McpStdioTransport;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.Banner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+import java.util.Arrays;
+
+/**
+ * Main application class for the MCP Server.
+ *
+ * This Spring Boot application provides an MCP (Model Context Protocol) server
+ * that allows AI assistants like Claude to interact with the Monthly Expense Tracker
+ * application using natural language.
+ *
+ * The server supports TWO execution modes:
+ *
+ * 1. STDIO MODE (for Claude Desktop):
+ *    - Communication via stdin/stdout pipes
+ *    - No web server (no HTTP/WebSocket)
+ *    - Automatically detected when launched by Claude Desktop
+ *    - Usage: java -jar mcp-server.jar --mode=stdio
+ *
+ * 2. WEB MODE (for manual testing):
+ *    - Full Spring Boot web server on port 8082
+ *    - HTTP endpoint: http://localhost:8082/api/mcp
+ *    - WebSocket endpoint: ws://localhost:8082/mcp
+ *    - Usage: java -jar mcp-server.jar --mode=web (default)
+ *
+ * Mode Detection:
+ * - Explicit: --mode=stdio or --mode=web command-line argument
+ * - Auto-detect: If no console available → stdio mode (Claude Desktop launch)
+ * - Default: Web mode (manual testing)
+ *
+ * The server:
+ * - Scans for @McpTool annotated methods and registers them automatically
+ * - Reuses all existing services from the backend module
+ * - Supports API key authentication for security (web mode)
+ * - Backend services: Scanned from com.expense.monthly package
+ * - Database: Inherited from backend configuration
+ */
+@SpringBootApplication
+@ComponentScan(basePackages = {
+        "com.expense.mcp",       // MCP server components
+        "com.expense.monthly"    // Backend components (services, repositories, config)
+})
+@EntityScan("com.expense.monthly.model")  // Scan backend entities
+@EnableJpaRepositories("com.expense.monthly.repository")  // Scan backend repositories
+@Slf4j
+public class McpServerApplication {
+
+    public static void main(String[] args) {
+        // Detect execution mode
+        String mode = detectMode(args);
+
+        log.info("Starting MCP Server for Monthly Expense Tracker in {} mode...", mode.toUpperCase());
+
+        if ("stdio".equalsIgnoreCase(mode)) {
+            startStdioMode(args);
+        } else {
+            startWebMode(args);
+        }
+    }
+
+    /**
+     * Detect execution mode from command-line arguments or environment.
+     *
+     * Priority:
+     * 1. --mode=stdio or --mode=web command-line argument
+     * 2. MCP_MODE environment variable
+     * 3. Auto-detect: System.console() == null → stdio (Claude Desktop)
+     * 4. Default: web mode
+     *
+     * @param args command-line arguments
+     * @return "stdio" or "web"
+     */
+    private static String detectMode(String[] args) {
+        // Check command-line arguments
+        for (String arg : args) {
+            if (arg.startsWith("--mode=")) {
+                String mode = arg.substring("--mode=".length());
+                log.info("Mode detected from command-line: {}", mode);
+                return mode;
+            }
+        }
+
+        // Check environment variable
+        String envMode = System.getenv("MCP_MODE");
+        if (envMode != null && !envMode.isEmpty()) {
+            log.info("Mode detected from environment: {}", envMode);
+            return envMode;
+        }
+
+        // Auto-detect: No console = likely launched by Claude Desktop
+        if (System.console() == null) {
+            log.info("No console detected - Assuming stdio mode (Claude Desktop launch)");
+            return "stdio";
+        }
+
+        // Default to web mode
+        log.info("Defaulting to web mode (manual launch)");
+        return "web";
+    }
+
+    /**
+     * Start server in STDIO mode.
+     *
+     * This mode:
+     * - Does NOT start a web server (no Tomcat, no HTTP/WebSocket)
+     * - Uses Spring Boot's non-web application context
+     * - Communicates via stdin/stdout pipes
+     * - Blocks on stdin until shutdown signal
+     *
+     * Used by: Claude Desktop (auto-launched)
+     *
+     * @param args command-line arguments
+     */
+    private static void startStdioMode(String[] args) {
+        log.info("Initializing Spring Boot context...");
+
+        // Create Spring application without web server
+        SpringApplication app = new SpringApplication(McpServerApplication.class);
+        app.setWebApplicationType(WebApplicationType.NONE);  // CRITICAL: No web server!
+        app.setBannerMode(Banner.Mode.OFF);  // Suppress banner for clean output
+
+        // Start Spring context (but not web server)
+        // This may take several seconds (database connections, JPA initialization, etc.)
+        ApplicationContext context = app.run(args);
+
+        log.info("Spring Boot context initialized successfully");
+
+        // IMPORTANT: Wait for all beans to be fully initialized
+        // This ensures database connections, JPA repositories, and all services are ready
+        // before we start accepting MCP requests from Claude Desktop
+        try {
+            // Small delay to ensure all async initialization completes
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            log.warn("Interrupted during initialization delay", e);
+        }
+
+        // Get stdio transport bean
+        McpStdioTransport transport = context.getBean(McpStdioTransport.class);
+
+        // Register shutdown hook for graceful cleanup
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            log.info("Shutdown signal received");
+            transport.shutdown();
+        }));
+
+        try {
+            // Start stdio transport - BLOCKS until stdin closes
+            log.info("MCP Server ready - Starting stdio transport");
+            transport.start();
+
+            log.info("Stdio transport stopped - Exiting");
+        } catch (Exception e) {
+            log.error("Fatal error in stdio transport", e);
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Start server in WEB mode.
+     *
+     * This mode:
+     * - Starts full Spring Boot web server (Tomcat)
+     * - HTTP endpoint: http://localhost:8082/api/mcp
+     * - WebSocket endpoint: ws://localhost:8082/mcp
+     * - Runs indefinitely until stopped
+     *
+     * Used by: Manual testing, development
+     *
+     * @param args command-line arguments
+     */
+    private static void startWebMode(String[] args) {
+        log.info("Initializing WEB transport (HTTP + WebSocket)...");
+
+        // Standard Spring Boot startup (current behavior)
+        SpringApplication.run(McpServerApplication.class, args);
+
+        log.info("MCP Server started in WEB mode");
+        log.info("HTTP endpoint: http://localhost:8082/api/mcp");
+        log.info("WebSocket endpoint: ws://localhost:8082/mcp");
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/annotations/McpParam.java
+++ b/mcp-server/src/main/java/com/expense/mcp/annotations/McpParam.java
@@ -1,0 +1,109 @@
+package com.expense.mcp.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Describes a parameter for an @McpTool method.
+ * Provides metadata for parameter validation and documentation.
+ *
+ * Example usage:
+ * <pre>
+ * @McpTool(name = "query_expenses", description = "Search expenses")
+ * public List&lt;Transaction&gt; queryExpenses(
+ *     @McpParam(
+ *         name = "category",
+ *         description = "Expense category (e.g., Groceries, Bills)",
+ *         required = false
+ *     ) String category,
+ *
+ *     @McpParam(
+ *         name = "minAmount",
+ *         description = "Minimum transaction amount",
+ *         required = false,
+ *         defaultValue = "0"
+ *     ) BigDecimal minAmount
+ * ) {
+ *     // Implementation
+ * }
+ * </pre>
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface McpParam {
+
+    /**
+     * Parameter name as it appears in the MCP request
+     * Convention: camelCase (e.g., "startDate", "category", "minAmount")
+     *
+     * If not specified, the actual parameter name from the method signature
+     * will be used (requires -parameters compiler flag)
+     */
+    String name() default "";
+
+    /**
+     * Human-readable description of the parameter
+     *
+     * Helps Claude understand:
+     * - What the parameter is for
+     * - What values are acceptable
+     * - Format requirements (e.g., "YYYY-MM-DD")
+     */
+    String description() default "";
+
+    /**
+     * Whether this parameter is required
+     * Default: false (optional)
+     *
+     * If true and the parameter is missing from the request,
+     * an invalid params error will be returned.
+     */
+    boolean required() default false;
+
+    /**
+     * Default value if parameter is not provided
+     * Format: String representation that will be parsed to the parameter type
+     *
+     * Examples:
+     * - "0" for numeric types
+     * - "true" for boolean
+     * - "2025-01-01" for dates
+     * - "" for empty string
+     */
+    String defaultValue() default "";
+
+    /**
+     * Optional regex pattern for string validation
+     * Example: "\\d{4}-\\d{2}-\\d{2}" for date validation
+     */
+    String pattern() default "";
+
+    /**
+     * Minimum value (for numeric parameters)
+     * Example: "0" for non-negative numbers
+     */
+    String min() default "";
+
+    /**
+     * Maximum value (for numeric parameters)
+     * Example: "12" for month parameter
+     */
+    String max() default "";
+
+    /**
+     * Allowed enum values (for string parameters)
+     * Example: {"Groceries", "Bills", "Transport"}
+     */
+    String[] allowedValues() default {};
+
+    /**
+     * Format hint for parameter parsing
+     * Examples: "date", "date-time", "email", "uri"
+     *
+     * Used for:
+     * - Better documentation
+     * - Client-side validation hints
+     * - Parsing guidance
+     */
+    String format() default "";
+}

--- a/mcp-server/src/main/java/com/expense/mcp/annotations/McpResource.java
+++ b/mcp-server/src/main/java/com/expense/mcp/annotations/McpResource.java
@@ -1,0 +1,40 @@
+package com.expense.mcp.annotations;
+
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks a class as an MCP resource containing tool methods.
+ * Classes annotated with @McpResource will be scanned for @McpTool methods
+ * and automatically registered with the MCP server.
+ *
+ * Example usage:
+ * <pre>
+ * @McpResource
+ * public class ExpenseTools {
+ *     @McpTool(name = "query_expenses", description = "Search expenses")
+ *     public List&lt;Transaction&gt; queryExpenses(...) { ... }
+ * }
+ * </pre>
+ *
+ * This annotation is also a Spring @Component, so classes will be
+ * automatically discovered by Spring's component scanning.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface McpResource {
+
+    /**
+     * Optional name for the resource
+     * If not specified, the class name will be used
+     */
+    String value() default "";
+
+    /**
+     * Optional description of what this resource provides
+     */
+    String description() default "";
+}

--- a/mcp-server/src/main/java/com/expense/mcp/annotations/McpTool.java
+++ b/mcp-server/src/main/java/com/expense/mcp/annotations/McpTool.java
@@ -1,0 +1,72 @@
+package com.expense.mcp.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks a method as an MCP tool that can be called by Claude.
+ * The method will be registered with the MCP server and exposed to clients.
+ *
+ * Example usage:
+ * <pre>
+ * @McpTool(
+ *     name = "query_expenses",
+ *     description = "Query expenses by date range, category, or merchant"
+ * )
+ * public List&lt;Transaction&gt; queryExpenses(
+ *     @McpParam(name = "startDate", required = false) LocalDate start,
+ *     @McpParam(name = "endDate", required = false) LocalDate end,
+ *     @McpParam(name = "category", required = false) String category
+ * ) {
+ *     // Implementation
+ * }
+ * </pre>
+ *
+ * Method requirements:
+ * - Must be public
+ * - Can have any return type (will be serialized to JSON)
+ * - Parameters should be annotated with @McpParam
+ * - Can throw exceptions (will be converted to MCP errors)
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface McpTool {
+
+    /**
+     * Tool name (unique identifier)
+     * Convention: snake_case (e.g., "query_expenses", "get_category_totals")
+     *
+     * This is the name Claude will use to invoke the tool.
+     */
+    String name();
+
+    /**
+     * Human-readable description of what the tool does
+     *
+     * This description helps Claude understand:
+     * - What the tool does
+     * - When to use it
+     * - What results to expect
+     *
+     * Be specific and include examples if helpful.
+     */
+    String description();
+
+    /**
+     * Optional category/group for organizing tools
+     * Examples: "query", "analysis", "reporting"
+     */
+    String category() default "";
+
+    /**
+     * Whether this tool requires authentication
+     * Default: true (inherits from server-level auth settings)
+     */
+    boolean requiresAuth() default true;
+
+    /**
+     * Optional examples of how to use this tool
+     * Format: JSON strings showing example invocations
+     */
+    String[] examples() default {};
+}

--- a/mcp-server/src/main/java/com/expense/mcp/config/JacksonConfig.java
+++ b/mcp-server/src/main/java/com/expense/mcp/config/JacksonConfig.java
@@ -1,0 +1,41 @@
+package com.expense.mcp.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * Jackson configuration for JSON serialization/deserialization.
+ * Configures proper handling of Java 8 date/time types and BigDecimal.
+ */
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // Register Java 8 date/time module
+        mapper.registerModule(new JavaTimeModule());
+
+        // Don't write dates as timestamps
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // CRITICAL: Disable pretty-printing for stdio transport
+        // Claude Desktop expects single-line JSON (no newlines)
+        // Pretty-printed JSON causes "Unexpected token" errors when read line-by-line
+        mapper.disable(SerializationFeature.INDENT_OUTPUT);
+
+        // Don't fail on unknown properties
+        mapper.configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        // Write BigDecimal as plain strings (not scientific notation)
+        mapper.enable(SerializationFeature.WRITE_BIGDECIMAL_AS_PLAIN);
+
+        return mapper;
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/config/McpServerConfig.java
+++ b/mcp-server/src/main/java/com/expense/mcp/config/McpServerConfig.java
@@ -1,0 +1,105 @@
+package com.expense.mcp.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration properties for the MCP server.
+ *
+ * Configure via application.yml:
+ * <pre>
+ * mcp:
+ *   server:
+ *     enabled: true
+ *     port: 8082
+ *     websocket:
+ *       path: /mcp
+ *       enabled: true
+ *     http:
+ *       enabled: true
+ *     auth:
+ *       enabled: true
+ *       api-keys:
+ *         - "your-api-key-here"
+ * </pre>
+ */
+@Configuration
+@ConfigurationProperties(prefix = "mcp.server")
+@Data
+public class McpServerConfig {
+
+    /**
+     * Whether MCP server is enabled
+     */
+    private boolean enabled = true;
+
+    /**
+     * WebSocket configuration
+     */
+    private WebSocketConfig websocket = new WebSocketConfig();
+
+    /**
+     * HTTP configuration
+     */
+    private HttpConfig http = new HttpConfig();
+
+    /**
+     * Authentication configuration
+     */
+    private AuthConfig auth = new AuthConfig();
+
+    @Data
+    public static class WebSocketConfig {
+        /**
+         * WebSocket endpoint path
+         */
+        private String path = "/mcp";
+
+        /**
+         * Whether WebSocket transport is enabled
+         */
+        private boolean enabled = true;
+
+        /**
+         * Maximum message size (bytes)
+         */
+        private int maxMessageSize = 1048576; // 1MB
+
+        /**
+         * Session timeout (milliseconds)
+         */
+        private long sessionTimeout = 300000; // 5 minutes
+    }
+
+    @Data
+    public static class HttpConfig {
+        /**
+         * Whether HTTP transport is enabled
+         */
+        private boolean enabled = true;
+
+        /**
+         * HTTP endpoint path
+         */
+        private String path = "/api/mcp";
+    }
+
+    @Data
+    public static class AuthConfig {
+        /**
+         * Whether authentication is enabled
+         */
+        private boolean enabled = false; // Disabled by default for local dev
+
+        /**
+         * List of valid API keys
+         */
+        private String[] apiKeys = new String[0];
+
+        /**
+         * API key header name
+         */
+        private String headerName = "X-MCP-API-Key";
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/core/McpParameterConverter.java
+++ b/mcp-server/src/main/java/com/expense/mcp/core/McpParameterConverter.java
@@ -1,0 +1,202 @@
+package com.expense.mcp.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Converts JSON parameters to Java types for tool method invocation.
+ * Handles type conversion, validation, and default values.
+ */
+@Component
+@Slf4j
+public class McpParameterConverter {
+
+    private final ObjectMapper objectMapper;
+
+    public McpParameterConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Convert a parameter value to the target type
+     *
+     * @param value Parameter value from JSON (can be null)
+     * @param metadata Parameter metadata
+     * @return Converted value
+     * @throws IllegalArgumentException if conversion fails or validation fails
+     */
+    public Object convert(Object value, ParameterMetadata metadata) {
+        // Handle null/missing values
+        if (value == null) {
+            if (metadata.isRequired() && !metadata.hasDefault()) {
+                throw new IllegalArgumentException(
+                        "Required parameter '" + metadata.getName() + "' is missing"
+                );
+            }
+            if (metadata.hasDefault()) {
+                value = metadata.getDefaultValue();
+            } else {
+                return null; // Optional parameter not provided
+            }
+        }
+
+        // Convert to target type
+        Object converted = convertToType(value, metadata.getType());
+
+        // Validate
+        validate(converted, metadata);
+
+        return converted;
+    }
+
+    /**
+     * Convert value to the specified type
+     */
+    private Object convertToType(Object value, Class<?> targetType) {
+        if (value == null) {
+            return null;
+        }
+
+        // Already correct type
+        if (targetType.isInstance(value)) {
+            return value;
+        }
+
+        // String conversion
+        String stringValue = value.toString();
+
+        try {
+            // String
+            if (targetType == String.class) {
+                return stringValue;
+            }
+
+            // Integer
+            if (targetType == Integer.class || targetType == int.class) {
+                return Integer.parseInt(stringValue);
+            }
+
+            // Long
+            if (targetType == Long.class || targetType == long.class) {
+                return Long.parseLong(stringValue);
+            }
+
+            // Double
+            if (targetType == Double.class || targetType == double.class) {
+                return Double.parseDouble(stringValue);
+            }
+
+            // Float
+            if (targetType == Float.class || targetType == float.class) {
+                return Float.parseFloat(stringValue);
+            }
+
+            // Boolean
+            if (targetType == Boolean.class || targetType == boolean.class) {
+                return Boolean.parseBoolean(stringValue);
+            }
+
+            // BigDecimal
+            if (targetType == BigDecimal.class) {
+                return new BigDecimal(stringValue);
+            }
+
+            // LocalDate
+            if (targetType == LocalDate.class) {
+                return LocalDate.parse(stringValue, DateTimeFormatter.ISO_LOCAL_DATE);
+            }
+
+            // LocalDateTime
+            if (targetType == LocalDateTime.class) {
+                return LocalDateTime.parse(stringValue, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+            }
+
+            // List (use Jackson for complex types)
+            if (List.class.isAssignableFrom(targetType)) {
+                return objectMapper.convertValue(value, objectMapper.getTypeFactory().constructCollectionType(List.class, Object.class));
+            }
+
+            // Map (use Jackson for complex types)
+            if (Map.class.isAssignableFrom(targetType)) {
+                return objectMapper.convertValue(value, objectMapper.getTypeFactory().constructMapType(Map.class, String.class, Object.class));
+            }
+
+            // Try Jackson as fallback
+            return objectMapper.convertValue(value, targetType);
+
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Cannot convert parameter to " + targetType.getSimpleName() + ": " + e.getMessage()
+            );
+        }
+    }
+
+    /**
+     * Validate a converted value against parameter metadata
+     */
+    private void validate(Object value, ParameterMetadata metadata) {
+        if (value == null) {
+            return; // Null already handled in convert()
+        }
+
+        // Pattern validation (for strings)
+        if (metadata.getPattern() != null && !metadata.getPattern().isEmpty() && value instanceof String) {
+            String stringValue = (String) value;
+            if (!stringValue.matches(metadata.getPattern())) {
+                throw new IllegalArgumentException(
+                        "Parameter '" + metadata.getName() + "' does not match pattern: " + metadata.getPattern()
+                );
+            }
+        }
+
+        // Enum validation (allowed values)
+        if (metadata.getAllowedValues() != null && metadata.getAllowedValues().length > 0 && value instanceof String) {
+            String stringValue = (String) value;
+            boolean found = false;
+            for (String allowed : metadata.getAllowedValues()) {
+                if (allowed.equals(stringValue)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                throw new IllegalArgumentException(
+                        "Parameter '" + metadata.getName() + "' must be one of: " +
+                                String.join(", ", metadata.getAllowedValues())
+                );
+            }
+        }
+
+        // Numeric range validation
+        if (value instanceof Number) {
+            Number numValue = (Number) value;
+            double doubleValue = numValue.doubleValue();
+
+            if (metadata.getMin() != null && !metadata.getMin().isEmpty()) {
+                double min = Double.parseDouble(metadata.getMin());
+                if (doubleValue < min) {
+                    throw new IllegalArgumentException(
+                            "Parameter '" + metadata.getName() + "' must be >= " + min
+                    );
+                }
+            }
+
+            if (metadata.getMax() != null && !metadata.getMax().isEmpty()) {
+                double max = Double.parseDouble(metadata.getMax());
+                if (doubleValue > max) {
+                    throw new IllegalArgumentException(
+                            "Parameter '" + metadata.getName() + "' must be <= " + max
+                    );
+                }
+            }
+        }
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/core/McpToolExecutor.java
+++ b/mcp-server/src/main/java/com/expense/mcp/core/McpToolExecutor.java
@@ -1,0 +1,153 @@
+package com.expense.mcp.core;
+
+import com.expense.mcp.protocol.McpError;
+import com.expense.mcp.protocol.McpToolResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+/**
+ * Executes MCP tools using reflection.
+ * Handles parameter conversion, method invocation, and result serialization.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class McpToolExecutor {
+
+    private final McpToolRegistry toolRegistry;
+    private final McpParameterConverter parameterConverter;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Execute a tool by name with the given arguments
+     *
+     * @param toolName Tool name
+     * @param arguments Tool arguments as a map
+     * @return Tool result
+     */
+    public McpToolResult execute(String toolName, Map<String, Object> arguments) {
+        log.debug("Executing tool: {} with arguments: {}", toolName, arguments);
+
+        try {
+            // Get registered tool
+            RegisteredTool tool = toolRegistry.getTool(toolName)
+                    .orElseThrow(() -> new IllegalArgumentException("Tool not found: " + toolName));
+
+            // Prepare method arguments
+            Object[] methodArgs = prepareMethodArguments(tool, arguments);
+
+            // Invoke method
+            Object result = invokeMethod(tool, methodArgs);
+
+            // Convert result to MCP format
+            return convertToMcpResult(result);
+
+        } catch (IllegalArgumentException e) {
+            // Parameter validation or tool not found errors
+            log.warn("Tool execution failed due to invalid arguments: {}", e.getMessage());
+            return McpToolResult.error(e.getMessage());
+
+        } catch (Exception e) {
+            // Unexpected errors
+            log.error("Tool execution failed: " + toolName, e);
+            return McpToolResult.error("Tool execution failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Prepare method arguments from JSON arguments map
+     */
+    private Object[] prepareMethodArguments(RegisteredTool tool, Map<String, Object> arguments) {
+        ParameterMetadata[] parameters = tool.getParameters();
+        Object[] methodArgs = new Object[parameters.length];
+
+        for (int i = 0; i < parameters.length; i++) {
+            ParameterMetadata param = parameters[i];
+            Object argValue = arguments != null ? arguments.get(param.getName()) : null;
+
+            try {
+                methodArgs[i] = parameterConverter.convert(argValue, param);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                        "Invalid parameter '" + param.getName() + "': " + e.getMessage()
+                );
+            }
+        }
+
+        return methodArgs;
+    }
+
+    /**
+     * Invoke the tool method
+     */
+    private Object invokeMethod(RegisteredTool tool, Object[] methodArgs) throws Exception {
+        Method method = tool.getMethod();
+        Object instance = tool.getInstance();
+
+        // Make method accessible if needed
+        if (!method.canAccess(instance)) {
+            method.setAccessible(true);
+        }
+
+        return method.invoke(instance, methodArgs);
+    }
+
+    /**
+     * Convert method result to MCP tool result format
+     */
+    private McpToolResult convertToMcpResult(Object result) {
+        if (result == null) {
+            return McpToolResult.text("Operation completed successfully (no result)");
+        }
+
+        // If result is already a McpToolResult, return it
+        if (result instanceof McpToolResult) {
+            return (McpToolResult) result;
+        }
+
+        // If result is a string, return as text
+        if (result instanceof String) {
+            return McpToolResult.text((String) result);
+        }
+
+        // For other types, serialize to JSON
+        try {
+            String json = objectMapper.writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(result);
+            return McpToolResult.text(json);
+        } catch (Exception e) {
+            log.error("Failed to serialize tool result to JSON", e);
+            return McpToolResult.text(result.toString());
+        }
+    }
+
+    /**
+     * Validate tool arguments before execution
+     * Returns an error if validation fails, null if valid
+     */
+    public McpError validateArguments(String toolName, Map<String, Object> arguments) {
+        try {
+            RegisteredTool tool = toolRegistry.getTool(toolName)
+                    .orElse(null);
+
+            if (tool == null) {
+                return McpError.toolNotFound(toolName);
+            }
+
+            // Try to prepare arguments (will throw if invalid)
+            prepareMethodArguments(tool, arguments);
+
+            return null; // Valid
+
+        } catch (IllegalArgumentException e) {
+            return McpError.invalidParams(e.getMessage());
+        } catch (Exception e) {
+            return McpError.internalError("Validation failed: " + e.getMessage());
+        }
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/core/McpToolRegistry.java
+++ b/mcp-server/src/main/java/com/expense/mcp/core/McpToolRegistry.java
@@ -1,0 +1,284 @@
+package com.expense.mcp.core;
+
+import com.expense.mcp.annotations.McpParam;
+import com.expense.mcp.annotations.McpResource;
+import com.expense.mcp.annotations.McpTool;
+import com.expense.mcp.protocol.McpToolDefinition;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Registry for MCP tools. Scans for @McpResource classes and @McpTool methods
+ * at startup and maintains a registry of available tools.
+ *
+ * This class is a Spring component and will be automatically instantiated.
+ */
+@Component
+@Slf4j
+public class McpToolRegistry {
+
+    private final ApplicationContext applicationContext;
+    private final Map<String, RegisteredTool> tools = new ConcurrentHashMap<>();
+
+    public McpToolRegistry(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    /**
+     * Scan for @McpResource beans and register their @McpTool methods
+     * This runs automatically after Spring initialization
+     */
+    @PostConstruct
+    public void scanAndRegisterTools() {
+        log.info("Scanning for MCP tools...");
+
+        // Find all beans annotated with @McpResource
+        Map<String, Object> resourceBeans = applicationContext.getBeansWithAnnotation(McpResource.class);
+
+        for (Map.Entry<String, Object> entry : resourceBeans.entrySet()) {
+            String beanName = entry.getKey();
+            Object bean = entry.getValue();
+            registerResourceBean(beanName, bean);
+        }
+
+        log.info("Registered {} MCP tools", tools.size());
+    }
+
+    /**
+     * Register all @McpTool methods from a resource bean
+     */
+    private void registerResourceBean(String beanName, Object bean) {
+        Class<?> clazz = bean.getClass();
+        McpResource resourceAnnotation = clazz.getAnnotation(McpResource.class);
+
+        log.debug("Scanning resource bean: {} ({})", beanName, clazz.getName());
+
+        // Find all methods annotated with @McpTool
+        for (Method method : clazz.getDeclaredMethods()) {
+            McpTool toolAnnotation = method.getAnnotation(McpTool.class);
+            if (toolAnnotation != null) {
+                registerTool(bean, method, toolAnnotation);
+            }
+        }
+    }
+
+    /**
+     * Register a single tool method
+     */
+    private void registerTool(Object instance, Method method, McpTool annotation) {
+        String toolName = annotation.name();
+
+        if (tools.containsKey(toolName)) {
+            log.warn("Tool '{}' is already registered, skipping duplicate", toolName);
+            return;
+        }
+
+        try {
+            // Build parameter metadata
+            ParameterMetadata[] paramMetadata = extractParameterMetadata(method);
+
+            // Build tool definition
+            McpToolDefinition definition = buildToolDefinition(annotation, paramMetadata);
+
+            // Create registered tool
+            RegisteredTool registeredTool = RegisteredTool.builder()
+                    .definition(definition)
+                    .instance(instance)
+                    .method(method)
+                    .parameters(paramMetadata)
+                    .category(annotation.category())
+                    .requiresAuth(annotation.requiresAuth())
+                    .build();
+
+            tools.put(toolName, registeredTool);
+            log.info("Registered tool: {} - {}", toolName, annotation.description());
+
+        } catch (Exception e) {
+            log.error("Failed to register tool: " + toolName, e);
+        }
+    }
+
+    /**
+     * Extract parameter metadata from method parameters
+     */
+    private ParameterMetadata[] extractParameterMetadata(Method method) {
+        Parameter[] parameters = method.getParameters();
+        ParameterMetadata[] metadata = new ParameterMetadata[parameters.length];
+
+        for (int i = 0; i < parameters.length; i++) {
+            Parameter param = parameters[i];
+            McpParam paramAnnotation = param.getAnnotation(McpParam.class);
+
+            String paramName = paramAnnotation != null && !paramAnnotation.name().isEmpty()
+                    ? paramAnnotation.name()
+                    : param.getName();
+
+            metadata[i] = ParameterMetadata.builder()
+                    .name(paramName)
+                    .description(paramAnnotation != null ? paramAnnotation.description() : "")
+                    .type(param.getType())
+                    .required(paramAnnotation != null && paramAnnotation.required())
+                    .defaultValue(paramAnnotation != null ? paramAnnotation.defaultValue() : "")
+                    .pattern(paramAnnotation != null ? paramAnnotation.pattern() : "")
+                    .min(paramAnnotation != null ? paramAnnotation.min() : "")
+                    .max(paramAnnotation != null ? paramAnnotation.max() : "")
+                    .allowedValues(paramAnnotation != null ? paramAnnotation.allowedValues() : new String[0])
+                    .format(paramAnnotation != null ? paramAnnotation.format() : "")
+                    .index(i)
+                    .build();
+        }
+
+        return metadata;
+    }
+
+    /**
+     * Build MCP tool definition from annotation and parameters
+     */
+    private McpToolDefinition buildToolDefinition(McpTool annotation, ParameterMetadata[] parameters) {
+        // Build input schema properties
+        Map<String, McpToolDefinition.PropertySchema> properties = new LinkedHashMap<>();
+        List<String> required = new ArrayList<>();
+
+        for (ParameterMetadata param : parameters) {
+            McpToolDefinition.PropertySchema propertySchema = buildPropertySchema(param);
+            properties.put(param.getName(), propertySchema);
+
+            if (param.isRequired()) {
+                required.add(param.getName());
+            }
+        }
+
+        // Build input schema
+        McpToolDefinition.InputSchema inputSchema = McpToolDefinition.InputSchema.builder()
+                .type("object")
+                .properties(properties)
+                .required(required.isEmpty() ? null : required)
+                .additionalProperties(false)
+                .build();
+
+        // Build tool definition
+        return McpToolDefinition.builder()
+                .name(annotation.name())
+                .description(annotation.description())
+                .inputSchema(inputSchema)
+                .build();
+    }
+
+    /**
+     * Build property schema for a parameter
+     */
+    private McpToolDefinition.PropertySchema buildPropertySchema(ParameterMetadata param) {
+        String jsonType = mapJavaTypeToJsonType(param.getType());
+
+        McpToolDefinition.PropertySchema.PropertySchemaBuilder builder = McpToolDefinition.PropertySchema.builder()
+                .type(jsonType)
+                .description(param.getDescription());
+
+        // Add format hint
+        if (param.getFormat() != null && !param.getFormat().isEmpty()) {
+            builder.format(param.getFormat());
+        }
+
+        // Add enum values
+        if (param.getAllowedValues() != null && param.getAllowedValues().length > 0) {
+            builder.enumValues(Arrays.asList(param.getAllowedValues()));
+        }
+
+        // Add numeric constraints
+        if (param.getMin() != null && !param.getMin().isEmpty()) {
+            builder.minimum(parseNumber(param.getMin()));
+        }
+        if (param.getMax() != null && !param.getMax().isEmpty()) {
+            builder.maximum(parseNumber(param.getMax()));
+        }
+
+        // Add pattern
+        if (param.getPattern() != null && !param.getPattern().isEmpty()) {
+            builder.pattern(param.getPattern());
+        }
+
+        // Add default value
+        if (param.hasDefault()) {
+            builder.defaultValue(param.getDefaultValue());
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Map Java type to JSON Schema type
+     */
+    private String mapJavaTypeToJsonType(Class<?> javaType) {
+        if (javaType == String.class) return "string";
+        if (javaType == Integer.class || javaType == int.class) return "integer";
+        if (javaType == Long.class || javaType == long.class) return "integer";
+        if (javaType == Double.class || javaType == double.class) return "number";
+        if (javaType == Float.class || javaType == float.class) return "number";
+        if (javaType == Boolean.class || javaType == boolean.class) return "boolean";
+        if (javaType == java.time.LocalDate.class) return "string"; // format: date
+        if (javaType == java.time.LocalDateTime.class) return "string"; // format: date-time
+        if (javaType == java.math.BigDecimal.class) return "number";
+        if (javaType.isArray() || List.class.isAssignableFrom(javaType)) return "array";
+        if (Map.class.isAssignableFrom(javaType)) return "object";
+        return "string"; // default
+    }
+
+    /**
+     * Parse a number from string
+     */
+    private Number parseNumber(String value) {
+        try {
+            if (value.contains(".")) {
+                return Double.parseDouble(value);
+            } else {
+                return Integer.parseInt(value);
+            }
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Get a registered tool by name
+     */
+    public Optional<RegisteredTool> getTool(String name) {
+        return Optional.ofNullable(tools.get(name));
+    }
+
+    /**
+     * Get all registered tools
+     */
+    public List<RegisteredTool> getAllTools() {
+        return new ArrayList<>(tools.values());
+    }
+
+    /**
+     * Get all tool definitions (for listing to clients)
+     */
+    public List<McpToolDefinition> getAllToolDefinitions() {
+        return tools.values().stream()
+                .map(RegisteredTool::getDefinition)
+                .toList();
+    }
+
+    /**
+     * Check if a tool exists
+     */
+    public boolean hasTool(String name) {
+        return tools.containsKey(name);
+    }
+
+    /**
+     * Get tool count
+     */
+    public int getToolCount() {
+        return tools.size();
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/core/ParameterMetadata.java
+++ b/mcp-server/src/main/java/com/expense/mcp/core/ParameterMetadata.java
@@ -1,0 +1,88 @@
+package com.expense.mcp.core;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Metadata about a tool parameter extracted from @McpParam annotation
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ParameterMetadata {
+
+    /**
+     * Parameter name
+     */
+    private String name;
+
+    /**
+     * Parameter description
+     */
+    private String description;
+
+    /**
+     * Parameter type (Java class)
+     */
+    private Class<?> type;
+
+    /**
+     * Whether the parameter is required
+     */
+    private boolean required;
+
+    /**
+     * Default value (as string)
+     */
+    private String defaultValue;
+
+    /**
+     * Validation pattern (regex)
+     */
+    private String pattern;
+
+    /**
+     * Minimum value (for numbers)
+     */
+    private String min;
+
+    /**
+     * Maximum value (for numbers)
+     */
+    private String max;
+
+    /**
+     * Allowed enum values
+     */
+    private String[] allowedValues;
+
+    /**
+     * Format hint (e.g., "date", "date-time")
+     */
+    private String format;
+
+    /**
+     * Parameter index in method signature
+     */
+    private int index;
+
+    /**
+     * Check if this parameter has a default value
+     */
+    public boolean hasDefault() {
+        return defaultValue != null && !defaultValue.isEmpty();
+    }
+
+    /**
+     * Check if this parameter has validation rules
+     */
+    public boolean hasValidation() {
+        return (pattern != null && !pattern.isEmpty()) ||
+                (min != null && !min.isEmpty()) ||
+                (max != null && !max.isEmpty()) ||
+                (allowedValues != null && allowedValues.length > 0);
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/core/RegisteredTool.java
+++ b/mcp-server/src/main/java/com/expense/mcp/core/RegisteredTool.java
@@ -1,0 +1,64 @@
+package com.expense.mcp.core;
+
+import com.expense.mcp.protocol.McpToolDefinition;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.lang.reflect.Method;
+
+/**
+ * Represents a registered MCP tool with its metadata.
+ * Combines the tool definition (for clients) with execution metadata (for the server).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisteredTool {
+
+    /**
+     * Tool definition (sent to clients)
+     */
+    private McpToolDefinition definition;
+
+    /**
+     * The object instance containing the tool method
+     */
+    private Object instance;
+
+    /**
+     * The method to invoke when the tool is called
+     */
+    private Method method;
+
+    /**
+     * Parameter metadata for validation and conversion
+     */
+    private ParameterMetadata[] parameters;
+
+    /**
+     * Tool category (for organization)
+     */
+    private String category;
+
+    /**
+     * Whether this tool requires authentication
+     */
+    private boolean requiresAuth;
+
+    /**
+     * Get the tool name
+     */
+    public String getName() {
+        return definition.getName();
+    }
+
+    /**
+     * Get the tool description
+     */
+    public String getDescription() {
+        return definition.getDescription();
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/protocol/McpError.java
+++ b/mcp-server/src/main/java/com/expense/mcp/protocol/McpError.java
@@ -1,0 +1,115 @@
+package com.expense.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a JSON-RPC 2.0 error object.
+ *
+ * Standard error codes (from JSON-RPC 2.0 spec):
+ * - -32700: Parse error (invalid JSON)
+ * - -32600: Invalid Request
+ * - -32601: Method not found
+ * - -32602: Invalid params
+ * - -32603: Internal error
+ * - -32000 to -32099: Server error (implementation-defined)
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class McpError {
+
+    /**
+     * Error code (integer)
+     */
+    @JsonProperty("code")
+    private int code;
+
+    /**
+     * Error message (human-readable)
+     */
+    @JsonProperty("message")
+    private String message;
+
+    /**
+     * Additional error data (optional)
+     */
+    @JsonProperty("data")
+    private Object data;
+
+    /**
+     * Standard JSON-RPC 2.0 error codes
+     */
+    public static class ErrorCode {
+        public static final int PARSE_ERROR = -32700;
+        public static final int INVALID_REQUEST = -32600;
+        public static final int METHOD_NOT_FOUND = -32601;
+        public static final int INVALID_PARAMS = -32602;
+        public static final int INTERNAL_ERROR = -32603;
+        public static final int TOOL_NOT_FOUND = -32001;
+        public static final int TOOL_EXECUTION_ERROR = -32002;
+        public static final int AUTHENTICATION_ERROR = -32003;
+    }
+
+    /**
+     * Create a parse error
+     */
+    public static McpError parseError(String message) {
+        return new McpError(ErrorCode.PARSE_ERROR, message, null);
+    }
+
+    /**
+     * Create an invalid request error
+     */
+    public static McpError invalidRequest(String message) {
+        return new McpError(ErrorCode.INVALID_REQUEST, message, null);
+    }
+
+    /**
+     * Create a method not found error
+     */
+    public static McpError methodNotFound(String method) {
+        return new McpError(ErrorCode.METHOD_NOT_FOUND, "Method not found: " + method, null);
+    }
+
+    /**
+     * Create an invalid params error
+     */
+    public static McpError invalidParams(String message) {
+        return new McpError(ErrorCode.INVALID_PARAMS, message, null);
+    }
+
+    /**
+     * Create an internal error
+     */
+    public static McpError internalError(String message) {
+        return new McpError(ErrorCode.INTERNAL_ERROR, message, null);
+    }
+
+    /**
+     * Create a tool not found error
+     */
+    public static McpError toolNotFound(String toolName) {
+        return new McpError(ErrorCode.TOOL_NOT_FOUND, "Tool not found: " + toolName, null);
+    }
+
+    /**
+     * Create a tool execution error
+     */
+    public static McpError toolExecutionError(String message, Object details) {
+        return new McpError(ErrorCode.TOOL_EXECUTION_ERROR, message, details);
+    }
+
+    /**
+     * Create an authentication error
+     */
+    public static McpError authenticationError(String message) {
+        return new McpError(ErrorCode.AUTHENTICATION_ERROR, message, null);
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/protocol/McpRequest.java
+++ b/mcp-server/src/main/java/com/expense/mcp/protocol/McpRequest.java
@@ -1,0 +1,136 @@
+package com.expense.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * Represents a JSON-RPC 2.0 request from the MCP client (Claude).
+ *
+ * Example request:
+ * {
+ *   "jsonrpc": "2.0",
+ *   "id": "req-123",
+ *   "method": "tools/call",
+ *   "params": {
+ *     "name": "query_expenses",
+ *     "arguments": {
+ *       "category": "Groceries",
+ *       "month": 12
+ *     }
+ *   }
+ * }
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class McpRequest {
+
+    /**
+     * JSON-RPC version (must be "2.0")
+     */
+    @JsonProperty("jsonrpc")
+    private String jsonrpc = "2.0";
+
+    /**
+     * Request identifier (can be string or number)
+     * Used to match requests with responses
+     */
+    @JsonProperty("id")
+    private Object id;
+
+    /**
+     * Method name being called
+     * MCP methods: "initialize", "tools/list", "tools/call", "resources/list", etc.
+     */
+    @JsonProperty("method")
+    private String method;
+
+    /**
+     * Method parameters as a map
+     * Structure depends on the method being called
+     */
+    @JsonProperty("params")
+    private Map<String, Object> params;
+
+    /**
+     * Get a typed parameter value from the params map
+     *
+     * @param key Parameter name
+     * @param type Expected type
+     * @return Parameter value cast to the expected type
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getParam(String key, Class<T> type) {
+        Object value = params != null ? params.get(key) : null;
+        if (value == null) {
+            return null;
+        }
+        return type.cast(value);
+    }
+
+    /**
+     * Get a parameter value as a String
+     *
+     * @param key Parameter name
+     * @return Parameter value as String, or null if not found
+     */
+    public String getParamAsString(String key) {
+        Object value = params != null ? params.get(key) : null;
+        return value != null ? value.toString() : null;
+    }
+
+    /**
+     * Check if this is a tool call request
+     *
+     * @return true if method is "tools/call"
+     */
+    public boolean isToolCall() {
+        return "tools/call".equals(method);
+    }
+
+    /**
+     * Check if this is a tools list request
+     *
+     * @return true if method is "tools/list"
+     */
+    public boolean isToolsList() {
+        return "tools/list".equals(method);
+    }
+
+    /**
+     * Check if this is an initialize request
+     *
+     * @return true if method is "initialize"
+     */
+    public boolean isInitialize() {
+        return "initialize".equals(method);
+    }
+
+    /**
+     * Check if this is a notification (one-way message, no response expected)
+     *
+     * In JSON-RPC 2.0:
+     * - Requests have an "id" field (require response)
+     * - Notifications have NO "id" field (no response needed)
+     *
+     * @return true if this is a notification
+     */
+    public boolean isNotification() {
+        return id == null;
+    }
+
+    /**
+     * Check if method is a notification method (starts with "notifications/")
+     *
+     * @return true if method starts with "notifications/"
+     */
+    public boolean isNotificationMethod() {
+        return method != null && method.startsWith("notifications/");
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/protocol/McpResponse.java
+++ b/mcp-server/src/main/java/com/expense/mcp/protocol/McpResponse.java
@@ -1,0 +1,135 @@
+package com.expense.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a JSON-RPC 2.0 response from the MCP server.
+ *
+ * Example success response:
+ * {
+ *   "jsonrpc": "2.0",
+ *   "id": "req-123",
+ *   "result": {
+ *     "content": [
+ *       {
+ *         "type": "text",
+ *         "text": "Found 15 grocery transactions totaling $487.32"
+ *       }
+ *     ]
+ *   }
+ * }
+ *
+ * Example error response:
+ * {
+ *   "jsonrpc": "2.0",
+ *   "id": "req-123",
+ *   "error": {
+ *     "code": -32602,
+ *     "message": "Invalid params: category is required"
+ *   }
+ * }
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class McpResponse {
+
+    /**
+     * JSON-RPC version (must be "2.0")
+     */
+    @JsonProperty("jsonrpc")
+    private String jsonrpc = "2.0";
+
+    /**
+     * Request identifier (must match the request)
+     */
+    @JsonProperty("id")
+    private Object id;
+
+    /**
+     * Result object (present on success, mutually exclusive with error)
+     */
+    @JsonProperty("result")
+    private Object result;
+
+    /**
+     * Error object (present on failure, mutually exclusive with result)
+     */
+    @JsonProperty("error")
+    private McpError error;
+
+    /**
+     * Create a success response
+     *
+     * @param id Request ID
+     * @param result Result object
+     * @return McpResponse with result
+     */
+    public static McpResponse success(Object id, Object result) {
+        return McpResponse.builder()
+                .jsonrpc("2.0")
+                .id(id)
+                .result(result)
+                .build();
+    }
+
+    /**
+     * Create an error response
+     *
+     * @param id Request ID
+     * @param error Error object
+     * @return McpResponse with error
+     */
+    public static McpResponse error(Object id, McpError error) {
+        return McpResponse.builder()
+                .jsonrpc("2.0")
+                .id(id)
+                .error(error)
+                .build();
+    }
+
+    /**
+     * Create an error response with code and message
+     *
+     * @param id Request ID
+     * @param code Error code
+     * @param message Error message
+     * @return McpResponse with error
+     */
+    public static McpResponse error(Object id, int code, String message) {
+        return error(id, new McpError(code, message, null));
+    }
+
+    /**
+     * Check if this is a success response
+     *
+     * Note: @JsonIgnore prevents this method from being serialized as "success" field
+     * in JSON output (JavaBeans convention treats isXxx() as a getter for property "xxx")
+     *
+     * @return true if result is present and error is null
+     */
+    @JsonIgnore
+    public boolean isSuccess() {
+        return result != null && error == null;
+    }
+
+    /**
+     * Check if this is an error response
+     *
+     * Note: @JsonIgnore prevents this method from being serialized as "error" field conflict
+     *
+     * @return true if error is present
+     */
+    @JsonIgnore
+    public boolean isError() {
+        return error != null;
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/protocol/McpToolDefinition.java
+++ b/mcp-server/src/main/java/com/expense/mcp/protocol/McpToolDefinition.java
@@ -1,0 +1,163 @@
+package com.expense.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents an MCP tool definition that describes a tool to the client (Claude).
+ *
+ * Example tool definition:
+ * {
+ *   "name": "query_expenses",
+ *   "description": "Query expenses by date range, category, or merchant",
+ *   "inputSchema": {
+ *     "type": "object",
+ *     "properties": {
+ *       "startDate": {
+ *         "type": "string",
+ *         "description": "Start date in YYYY-MM-DD format",
+ *         "format": "date"
+ *       },
+ *       "category": {
+ *         "type": "string",
+ *         "description": "Expense category (e.g., Groceries, Bills)"
+ *       }
+ *     }
+ *   }
+ * }
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class McpToolDefinition {
+
+    /**
+     * Tool name (unique identifier)
+     * Convention: snake_case (e.g., "query_expenses")
+     */
+    @JsonProperty("name")
+    private String name;
+
+    /**
+     * Human-readable description of what the tool does
+     * Helps Claude understand when to use this tool
+     */
+    @JsonProperty("description")
+    private String description;
+
+    /**
+     * JSON Schema describing the tool's input parameters
+     * Follows JSON Schema Draft 7 specification
+     */
+    @JsonProperty("inputSchema")
+    private InputSchema inputSchema;
+
+    /**
+     * Represents the JSON Schema for tool input parameters
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class InputSchema {
+
+        /**
+         * Schema type (usually "object")
+         */
+        @JsonProperty("type")
+        private String type;
+
+        /**
+         * Map of property name to property schema
+         */
+        @JsonProperty("properties")
+        private Map<String, PropertySchema> properties;
+
+        /**
+         * List of required property names
+         */
+        @JsonProperty("required")
+        private List<String> required;
+
+        /**
+         * Additional properties allowed (default: false)
+         */
+        @JsonProperty("additionalProperties")
+        private Boolean additionalProperties;
+    }
+
+    /**
+     * Represents a property schema within the input schema
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class PropertySchema {
+
+        /**
+         * Property type (string, number, integer, boolean, array, object)
+         */
+        @JsonProperty("type")
+        private String type;
+
+        /**
+         * Property description
+         */
+        @JsonProperty("description")
+        private String description;
+
+        /**
+         * Format hint (e.g., "date", "date-time", "email")
+         */
+        @JsonProperty("format")
+        private String format;
+
+        /**
+         * Enum values (for string types)
+         */
+        @JsonProperty("enum")
+        private List<String> enumValues;
+
+        /**
+         * Minimum value (for numeric types)
+         */
+        @JsonProperty("minimum")
+        private Number minimum;
+
+        /**
+         * Maximum value (for numeric types)
+         */
+        @JsonProperty("maximum")
+        private Number maximum;
+
+        /**
+         * Pattern (regex) for string validation
+         */
+        @JsonProperty("pattern")
+        private String pattern;
+
+        /**
+         * Items schema (for array types)
+         */
+        @JsonProperty("items")
+        private PropertySchema items;
+
+        /**
+         * Default value
+         */
+        @JsonProperty("default")
+        private Object defaultValue;
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/protocol/McpToolResult.java
+++ b/mcp-server/src/main/java/com/expense/mcp/protocol/McpToolResult.java
@@ -1,0 +1,135 @@
+package com.expense.mcp.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents the result of a tool execution.
+ * MCP tools return content blocks (text, images, resources, etc.)
+ *
+ * Example tool result:
+ * {
+ *   "content": [
+ *     {
+ *       "type": "text",
+ *       "text": "Found 15 transactions totaling $487.32"
+ *     }
+ *   ],
+ *   "isError": false
+ * }
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class McpToolResult {
+
+    /**
+     * List of content blocks returned by the tool
+     */
+    @JsonProperty("content")
+    @Builder.Default
+    private List<ContentBlock> content = new ArrayList<>();
+
+    /**
+     * Whether this result represents an error
+     */
+    @JsonProperty("isError")
+    @Builder.Default
+    private boolean isError = false;
+
+    /**
+     * Represents a content block (text, image, resource reference, etc.)
+     */
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ContentBlock {
+
+        /**
+         * Content type (text, image, resource)
+         */
+        @JsonProperty("type")
+        private String type;
+
+        /**
+         * Text content (for type="text")
+         */
+        @JsonProperty("text")
+        private String text;
+
+        /**
+         * Image data (for type="image")
+         */
+        @JsonProperty("data")
+        private String data;
+
+        /**
+         * MIME type (for images)
+         */
+        @JsonProperty("mimeType")
+        private String mimeType;
+
+        /**
+         * Resource URI (for type="resource")
+         */
+        @JsonProperty("resource")
+        private String resource;
+    }
+
+    /**
+     * Create a text result
+     *
+     * @param text Text content
+     * @return McpToolResult with text content
+     */
+    public static McpToolResult text(String text) {
+        ContentBlock block = ContentBlock.builder()
+                .type("text")
+                .text(text)
+                .build();
+
+        return McpToolResult.builder()
+                .content(List.of(block))
+                .isError(false)
+                .build();
+    }
+
+    /**
+     * Create an error result
+     *
+     * @param errorMessage Error message
+     * @return McpToolResult with error flag
+     */
+    public static McpToolResult error(String errorMessage) {
+        ContentBlock block = ContentBlock.builder()
+                .type("text")
+                .text("Error: " + errorMessage)
+                .build();
+
+        return McpToolResult.builder()
+                .content(List.of(block))
+                .isError(true)
+                .build();
+    }
+
+    /**
+     * Create a structured JSON result as text
+     *
+     * @param json JSON string
+     * @return McpToolResult with JSON text
+     */
+    public static McpToolResult json(String json) {
+        return text(json);
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/security/ApiKeyAuthFilter.java
+++ b/mcp-server/src/main/java/com/expense/mcp/security/ApiKeyAuthFilter.java
@@ -1,0 +1,91 @@
+package com.expense.mcp.security;
+
+import com.expense.mcp.config.McpServerConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * Filter for API key authentication.
+ * Checks for valid API key in the configured header.
+ *
+ * Only active when mcp.server.auth.enabled=true
+ */
+@Component
+@ConditionalOnProperty(prefix = "mcp.server.auth", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+@Slf4j
+public class ApiKeyAuthFilter extends OncePerRequestFilter {
+
+    private final McpServerConfig serverConfig;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        // Skip authentication for health check endpoints
+        String requestURI = request.getRequestURI();
+        if (requestURI.contains("/health") || requestURI.contains("/actuator")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // Get API key from header
+        String headerName = serverConfig.getAuth().getHeaderName();
+        String providedApiKey = request.getHeader(headerName);
+
+        if (providedApiKey == null || providedApiKey.isEmpty()) {
+            log.warn("Missing API key in request: uri={}", requestURI);
+            sendUnauthorizedResponse(response, "Missing API key");
+            return;
+        }
+
+        // Validate API key
+        String[] validApiKeys = serverConfig.getAuth().getApiKeys();
+        boolean isValid = Arrays.asList(validApiKeys).contains(providedApiKey);
+
+        if (!isValid) {
+            log.warn("Invalid API key in request: uri={}", requestURI);
+            sendUnauthorizedResponse(response, "Invalid API key");
+            return;
+        }
+
+        // API key is valid, continue
+        log.debug("API key validated successfully");
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Send 401 Unauthorized response with JSON error
+     */
+    private void sendUnauthorizedResponse(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+
+        Map<String, Object> error = Map.of(
+                "jsonrpc", "2.0",
+                "id", null,
+                "error", Map.of(
+                        "code", -32003,
+                        "message", message
+                )
+        );
+
+        response.getWriter().write(objectMapper.writeValueAsString(error));
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/tools/ExpenseTools.java
+++ b/mcp-server/src/main/java/com/expense/mcp/tools/ExpenseTools.java
@@ -1,0 +1,350 @@
+package com.expense.mcp.tools;
+
+import com.expense.mcp.annotations.McpParam;
+import com.expense.mcp.annotations.McpResource;
+import com.expense.mcp.annotations.McpTool;
+import com.expense.monthly.model.Transaction;
+import com.expense.monthly.service.TransactionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * MCP tools for querying and analyzing expenses.
+ * Reuses existing TransactionService from the backend module.
+ */
+@McpResource(description = "Tools for querying and analyzing monthly expenses")
+@Slf4j
+@RequiredArgsConstructor
+public class ExpenseTools {
+
+    private final TransactionService transactionService;
+
+    /**
+     * Query expenses with various filters.
+     * Returns transactions matching the specified criteria.
+     */
+    @McpTool(
+            name = "query_expenses",
+            description = "Query expenses by date range, category, description, or amount range. " +
+                    "All parameters are optional - use any combination to filter results."
+    )
+    public Map<String, Object> queryExpenses(
+            @McpParam(
+                    name = "startDate",
+                    description = "Start date in YYYY-MM-DD format (e.g., '2025-01-01')",
+                    format = "date",
+                    required = false
+            ) LocalDate startDate,
+
+            @McpParam(
+                    name = "endDate",
+                    description = "End date in YYYY-MM-DD format (e.g., '2025-12-31')",
+                    format = "date",
+                    required = false
+            ) LocalDate endDate,
+
+            @McpParam(
+                    name = "category",
+                    description = "Expense category (e.g., 'Groceries', 'Bills', 'Transport')",
+                    required = false
+            ) String category,
+
+            @McpParam(
+                    name = "description",
+                    description = "Search text to find in transaction descriptions (case-insensitive)",
+                    required = false
+            ) String description,
+
+            @McpParam(
+                    name = "minAmount",
+                    description = "Minimum transaction amount",
+                    required = false
+            ) BigDecimal minAmount,
+
+            @McpParam(
+                    name = "maxAmount",
+                    description = "Maximum transaction amount",
+                    required = false
+            ) BigDecimal maxAmount,
+
+            @McpParam(
+                    name = "month",
+                    description = "Month (1-12)",
+                    min = "1",
+                    max = "12",
+                    required = false
+            ) Integer month,
+
+            @McpParam(
+                    name = "year",
+                    description = "Year (e.g., 2025)",
+                    min = "2000",
+                    max = "2100",
+                    required = false
+            ) Integer year
+    ) {
+        log.info("Query expenses: startDate={}, endDate={}, category={}, description={}, month={}, year={}",
+                startDate, endDate, category, description, month, year);
+
+        // Start with all transactions or filter by month/year
+        List<Transaction> transactions;
+        if (month != null && year != null) {
+            transactions = transactionService.getTransactionsByMonth(month, year);
+        } else {
+            transactions = transactionService.getAllTransactions();
+        }
+
+        // Apply filters
+        if (category != null && !category.isEmpty()) {
+            String categoryLower = category.toLowerCase();
+            transactions = transactions.stream()
+                    .filter(t -> t.getCategory().toLowerCase().equals(categoryLower))
+                    .collect(Collectors.toList());
+        }
+
+        if (description != null && !description.isEmpty()) {
+            String descLower = description.toLowerCase();
+            transactions = transactions.stream()
+                    .filter(t -> t.getDescription().toLowerCase().contains(descLower))
+                    .collect(Collectors.toList());
+        }
+
+        if (startDate != null) {
+            transactions = transactions.stream()
+                    .filter(t -> !t.getDate().isBefore(startDate))
+                    .collect(Collectors.toList());
+        }
+
+        if (endDate != null) {
+            transactions = transactions.stream()
+                    .filter(t -> !t.getDate().isAfter(endDate))
+                    .collect(Collectors.toList());
+        }
+
+        if (minAmount != null) {
+            transactions = transactions.stream()
+                    .filter(t -> t.getAmount().compareTo(minAmount) >= 0)
+                    .collect(Collectors.toList());
+        }
+
+        if (maxAmount != null) {
+            transactions = transactions.stream()
+                    .filter(t -> t.getAmount().compareTo(maxAmount) <= 0)
+                    .collect(Collectors.toList());
+        }
+
+        // Calculate total
+        BigDecimal total = transactions.stream()
+                .map(Transaction::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // Build response
+        Map<String, Object> result = new HashMap<>();
+        result.put("count", transactions.size());
+        result.put("total", total);
+        result.put("transactions", transactions);
+
+        return result;
+    }
+
+    /**
+     * Get spending totals grouped by category.
+     */
+    @McpTool(
+            name = "get_category_totals",
+            description = "Get total spending by category. Optionally filter by month and year. " +
+                    "Returns a breakdown showing how much was spent in each category."
+    )
+    public Map<String, Object> getCategoryTotals(
+            @McpParam(
+                    name = "month",
+                    description = "Month (1-12). If provided, requires year as well.",
+                    min = "1",
+                    max = "12",
+                    required = false
+            ) Integer month,
+
+            @McpParam(
+                    name = "year",
+                    description = "Year (e.g., 2025)",
+                    min = "2000",
+                    max = "2100",
+                    required = false
+            ) Integer year
+    ) {
+        log.info("Get category totals: month={}, year={}", month, year);
+
+        Map<String, BigDecimal> categoryTotals = transactionService.calculateTotalsByCategory(month, year);
+
+        // Sort by amount (descending)
+        List<Map.Entry<String, BigDecimal>> sortedEntries = categoryTotals.entrySet().stream()
+                .sorted((e1, e2) -> e2.getValue().compareTo(e1.getValue()))
+                .collect(Collectors.toList());
+
+        // Calculate grand total
+        BigDecimal grandTotal = categoryTotals.values().stream()
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // Build response
+        Map<String, Object> result = new HashMap<>();
+        result.put("categoryTotals", categoryTotals);
+        result.put("sortedCategories", sortedEntries.stream()
+                .map(e -> Map.of("category", e.getKey(), "amount", e.getValue()))
+                .collect(Collectors.toList()));
+        result.put("grandTotal", grandTotal);
+        result.put("categoryCount", categoryTotals.size());
+
+        return result;
+    }
+
+    /**
+     * Get monthly spending summary for a specific year.
+     */
+    @McpTool(
+            name = "get_monthly_summary",
+            description = "Get total spending for each month in a specific year. " +
+                    "Returns a breakdown by month (1-12) with totals."
+    )
+    public Map<String, Object> getMonthlySummary(
+            @McpParam(
+                    name = "year",
+                    description = "Year to analyze (e.g., 2025)",
+                    min = "2000",
+                    max = "2100",
+                    required = true
+            ) Integer year
+    ) {
+        log.info("Get monthly summary for year: {}", year);
+
+        Map<Integer, BigDecimal> monthlyTotals = transactionService.calculateMonthlyTotals(year);
+
+        // Calculate yearly total
+        BigDecimal yearTotal = monthlyTotals.values().stream()
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // Calculate average monthly spending
+        BigDecimal avgMonthly = monthlyTotals.isEmpty()
+                ? BigDecimal.ZERO
+                : yearTotal.divide(BigDecimal.valueOf(monthlyTotals.size()), 2, BigDecimal.ROUND_HALF_UP);
+
+        // Find highest spending month
+        Map.Entry<Integer, BigDecimal> highestMonth = monthlyTotals.entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .orElse(null);
+
+        // Build response
+        Map<String, Object> result = new HashMap<>();
+        result.put("year", year);
+        result.put("monthlyTotals", monthlyTotals);
+        result.put("yearTotal", yearTotal);
+        result.put("avgMonthly", avgMonthly);
+        if (highestMonth != null) {
+            result.put("highestSpendingMonth", Map.of(
+                    "month", highestMonth.getKey(),
+                    "amount", highestMonth.getValue()
+            ));
+        }
+
+        return result;
+    }
+
+    /**
+     * Get total spending across all transactions.
+     */
+    @McpTool(
+            name = "get_total_spending",
+            description = "Get the total amount of all expenses in the database. " +
+                    "Returns overall spending statistics."
+    )
+    public Map<String, Object> getTotalSpending() {
+        log.info("Get total spending");
+
+        BigDecimal total = transactionService.calculateTotalAmount();
+        List<Transaction> allTransactions = transactionService.getAllTransactions();
+
+        // Calculate average transaction amount
+        BigDecimal avgAmount = allTransactions.isEmpty()
+                ? BigDecimal.ZERO
+                : total.divide(BigDecimal.valueOf(allTransactions.size()), 2, BigDecimal.ROUND_HALF_UP);
+
+        // Find largest transaction
+        Transaction largestTransaction = allTransactions.stream()
+                .max((t1, t2) -> t1.getAmount().compareTo(t2.getAmount()))
+                .orElse(null);
+
+        // Build response
+        Map<String, Object> result = new HashMap<>();
+        result.put("totalAmount", total);
+        result.put("transactionCount", allTransactions.size());
+        result.put("averageAmount", avgAmount);
+        if (largestTransaction != null) {
+            result.put("largestTransaction", Map.of(
+                    "amount", largestTransaction.getAmount(),
+                    "description", largestTransaction.getDescription(),
+                    "category", largestTransaction.getCategory(),
+                    "date", largestTransaction.getDate()
+            ));
+        }
+
+        return result;
+    }
+
+    /**
+     * Search transactions by description text.
+     */
+    @McpTool(
+            name = "search_transactions",
+            description = "Full-text search on transaction descriptions. " +
+                    "Returns all transactions containing the search text (case-insensitive)."
+    )
+    public Map<String, Object> searchTransactions(
+            @McpParam(
+                    name = "searchText",
+                    description = "Text to search for in transaction descriptions",
+                    required = true
+            ) String searchText
+    ) {
+        log.info("Search transactions: searchText={}", searchText);
+
+        List<Transaction> transactions = transactionService.getTransactionsByDescription(searchText);
+
+        // Calculate total of matching transactions
+        BigDecimal total = transactions.stream()
+                .map(Transaction::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // Build response
+        Map<String, Object> result = new HashMap<>();
+        result.put("searchText", searchText);
+        result.put("count", transactions.size());
+        result.put("total", total);
+        result.put("transactions", transactions);
+
+        return result;
+    }
+
+    /**
+     * Get primary currency used in the database.
+     */
+    @McpTool(
+            name = "get_primary_currency",
+            description = "Get the primary currency code used for transactions (e.g., 'USD', 'EUR', 'GBP')."
+    )
+    public Map<String, Object> getPrimaryCurrency() {
+        log.info("Get primary currency");
+
+        String primaryCurrency = transactionService.getPrimaryCurrency();
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("currency", primaryCurrency);
+
+        return result;
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/transport/McpHttpController.java
+++ b/mcp-server/src/main/java/com/expense/mcp/transport/McpHttpController.java
@@ -1,0 +1,75 @@
+package com.expense.mcp.transport;
+
+import com.expense.mcp.config.McpServerConfig;
+import com.expense.mcp.protocol.McpError;
+import com.expense.mcp.protocol.McpRequest;
+import com.expense.mcp.protocol.McpResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * HTTP controller for MCP protocol.
+ * Provides a simple HTTP POST endpoint for MCP requests.
+ *
+ * Endpoint: POST /api/mcp
+ * Content-Type: application/json
+ *
+ * Example request:
+ * POST http://localhost:8082/api/mcp
+ * {
+ *   "jsonrpc": "2.0",
+ *   "id": "req-1",
+ *   "method": "tools/list",
+ *   "params": {}
+ * }
+ */
+@RestController
+@RequestMapping("${mcp.server.http.path:/api/mcp}")
+@ConditionalOnProperty(prefix = "mcp.server.http", name = "enabled", havingValue = "true", matchIfMissing = true)
+@RequiredArgsConstructor
+@Slf4j
+public class McpHttpController {
+
+    private final McpRequestHandler requestHandler;
+    private final McpServerConfig serverConfig;
+
+    /**
+     * Handle MCP requests via HTTP POST
+     *
+     * @param request MCP request
+     * @return MCP response
+     */
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<McpResponse> handleRequest(@RequestBody McpRequest request) {
+        log.debug("Received HTTP MCP request: method={}, id={}", request.getMethod(), request.getId());
+
+        try {
+            McpResponse response = requestHandler.handleRequest(request);
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("Error handling HTTP MCP request", e);
+
+            McpResponse errorResponse = McpResponse.error(
+                    request.getId(),
+                    McpError.internalError("Request handling failed: " + e.getMessage())
+            );
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(errorResponse);
+        }
+    }
+
+    /**
+     * Health check endpoint
+     */
+    @GetMapping("/health")
+    public ResponseEntity<String> health() {
+        return ResponseEntity.ok("MCP HTTP endpoint is healthy");
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/transport/McpRequestHandler.java
+++ b/mcp-server/src/main/java/com/expense/mcp/transport/McpRequestHandler.java
@@ -1,0 +1,198 @@
+package com.expense.mcp.transport;
+
+import com.expense.mcp.core.McpToolExecutor;
+import com.expense.mcp.core.McpToolRegistry;
+import com.expense.mcp.protocol.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Handles MCP requests and generates responses.
+ * Used by both WebSocket and HTTP transport layers.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class McpRequestHandler {
+
+    private final McpToolRegistry toolRegistry;
+    private final McpToolExecutor toolExecutor;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Handle an MCP request and generate a response
+     *
+     * @param request MCP request
+     * @return MCP response, or null for notifications (no response needed)
+     */
+    public McpResponse handleRequest(McpRequest request) {
+        log.debug("Handling MCP request: method={}, id={}", request.getMethod(), request.getId());
+
+        try {
+            // Handle notifications (no response required)
+            if (request.isNotification() || request.isNotificationMethod()) {
+                handleNotification(request);
+                return null; // No response for notifications
+            }
+
+            // Route to appropriate handler based on method
+            if (request.isInitialize()) {
+                return handleInitialize(request);
+            } else if (request.isToolsList()) {
+                return handleToolsList(request);
+            } else if (request.isToolCall()) {
+                return handleToolCall(request);
+            } else {
+                return McpResponse.error(
+                        request.getId(),
+                        McpError.methodNotFound(request.getMethod())
+                );
+            }
+
+        } catch (Exception e) {
+            log.error("Error handling MCP request", e);
+            return McpResponse.error(
+                    request.getId(),
+                    McpError.internalError("Request handling failed: " + e.getMessage())
+            );
+        }
+    }
+
+    /**
+     * Handle MCP notifications (one-way messages, no response)
+     *
+     * Common notifications:
+     * - notifications/initialized - Client finished initialization
+     * - notifications/cancelled - Client cancelled a request
+     * - notifications/progress - Progress update
+     *
+     * @param request Notification request
+     */
+    private void handleNotification(McpRequest request) {
+        log.debug("Received notification: {}", request.getMethod());
+
+        // Handle specific notifications if needed
+        switch (request.getMethod()) {
+            case "notifications/initialized":
+                log.info("Client initialization complete");
+                break;
+            case "notifications/cancelled":
+                log.debug("Client cancelled request");
+                break;
+            case "notifications/progress":
+                log.debug("Progress notification received");
+                break;
+            default:
+                log.debug("Unknown notification: {}", request.getMethod());
+        }
+    }
+
+    /**
+     * Handle initialize request
+     * Returns server capabilities and information
+     */
+    private McpResponse handleInitialize(McpRequest request) {
+        log.info("Handling initialize request");
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("protocolVersion", "2024-11-05");
+        result.put("serverInfo", Map.of(
+                "name", "monthly-expense-mcp-server",
+                "version", "1.0.0",
+                "description", "MCP server for Monthly Expense Tracker - AI-assisted expense analysis"
+        ));
+        result.put("capabilities", Map.of(
+                "tools", Map.of("supported", true),
+                "resources", Map.of("supported", false),
+                "prompts", Map.of("supported", false)
+        ));
+
+        return McpResponse.success(request.getId(), result);
+    }
+
+    /**
+     * Handle tools/list request
+     * Returns list of available tools
+     */
+    private McpResponse handleToolsList(McpRequest request) {
+        log.info("Handling tools/list request");
+
+        List<McpToolDefinition> tools = toolRegistry.getAllToolDefinitions();
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("tools", tools);
+
+        return McpResponse.success(request.getId(), result);
+    }
+
+    /**
+     * Handle tools/call request
+     * Executes a tool and returns the result
+     */
+    @SuppressWarnings("unchecked")
+    private McpResponse handleToolCall(McpRequest request) {
+        Map<String, Object> params = request.getParams();
+        if (params == null) {
+            return McpResponse.error(
+                    request.getId(),
+                    McpError.invalidParams("Missing params")
+            );
+        }
+
+        String toolName = (String) params.get("name");
+        if (toolName == null || toolName.isEmpty()) {
+            return McpResponse.error(
+                    request.getId(),
+                    McpError.invalidParams("Missing tool name")
+            );
+        }
+
+        Map<String, Object> arguments = params.containsKey("arguments")
+                ? (Map<String, Object>) params.get("arguments")
+                : new HashMap<>();
+
+        log.info("Executing tool: {} with arguments: {}", toolName, arguments);
+
+        // Check if tool exists
+        if (!toolRegistry.hasTool(toolName)) {
+            return McpResponse.error(
+                    request.getId(),
+                    McpError.toolNotFound(toolName)
+            );
+        }
+
+        // Execute tool
+        McpToolResult toolResult = toolExecutor.execute(toolName, arguments);
+
+        // Build response
+        return McpResponse.success(request.getId(), toolResult);
+    }
+
+    /**
+     * Parse JSON string to McpRequest
+     *
+     * @param json JSON string
+     * @return Parsed request
+     * @throws Exception if parsing fails
+     */
+    public McpRequest parseRequest(String json) throws Exception {
+        return objectMapper.readValue(json, McpRequest.class);
+    }
+
+    /**
+     * Serialize McpResponse to JSON string
+     *
+     * @param response Response object
+     * @return JSON string
+     * @throws Exception if serialization fails
+     */
+    public String serializeResponse(McpResponse response) throws Exception {
+        return objectMapper.writeValueAsString(response);
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/transport/McpStdioTransport.java
+++ b/mcp-server/src/main/java/com/expense/mcp/transport/McpStdioTransport.java
@@ -1,0 +1,180 @@
+package com.expense.mcp.transport;
+
+import com.expense.mcp.protocol.McpRequest;
+import com.expense.mcp.protocol.McpResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Stdio transport implementation for MCP protocol.
+ *
+ * This transport layer handles communication with Claude Desktop via stdin/stdout:
+ * - Reads JSON-RPC requests from System.in (stdin) line-by-line
+ * - Writes JSON-RPC responses to System.out (stdout) as pure JSON
+ * - Logs are redirected to System.err to keep stdout clean
+ *
+ * Communication Flow:
+ * 1. Claude Desktop writes JSON-RPC to our stdin
+ * 2. We read line-by-line (blocking)
+ * 3. Parse JSON → McpRequest
+ * 4. Pass to McpRequestHandler for processing
+ * 5. Serialize response → JSON
+ * 6. Write to stdout (flush immediately)
+ * 7. Claude Desktop reads from our stdout
+ *
+ * Thread Safety:
+ * - Single-threaded: Main thread blocks on stdin read
+ * - stdout writes are synchronized via PrintWriter
+ * - Shutdown flag is atomic for safe termination
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class McpStdioTransport {
+
+    private final McpRequestHandler requestHandler;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private BufferedReader stdin;
+    private PrintWriter stdout;
+
+    /**
+     * Start the stdio transport loop.
+     * This method blocks until shutdown() is called or stdin is closed.
+     *
+     * @throws Exception if initialization or I/O fails
+     */
+    public void start() throws Exception {
+        if (!running.compareAndSet(false, true)) {
+            log.warn("Stdio transport already running");
+            return;
+        }
+
+        log.info("Starting MCP Stdio Transport...");
+
+        // Initialize stdin/stdout streams
+        stdin = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
+        stdout = new PrintWriter(System.out, true, StandardCharsets.UTF_8); // Auto-flush enabled
+
+        log.info("MCP Stdio Transport started - Listening on stdin");
+
+        // Main event loop - blocks on stdin.readLine()
+        try {
+            while (running.get()) {
+                String line = stdin.readLine();
+
+                // EOF (Ctrl+D) or stream closed
+                if (line == null) {
+                    log.info("Stdin closed (EOF) - Shutting down");
+                    break;
+                }
+
+                // Skip empty lines
+                if (line.trim().isEmpty()) {
+                    continue;
+                }
+
+                // Process the request
+                handleRequest(line);
+            }
+        } catch (Exception e) {
+            log.error("Error in stdio transport loop", e);
+            throw e;
+        } finally {
+            cleanup();
+        }
+    }
+
+    /**
+     * Handle a single JSON-RPC request.
+     *
+     * @param jsonLine JSON-RPC request as string
+     */
+    private void handleRequest(String jsonLine) {
+        try {
+            // Log to stderr (not stdout!)
+            log.debug("Received: {}", jsonLine);
+
+            // Parse request
+            McpRequest request = requestHandler.parseRequest(jsonLine);
+
+            // Handle request using existing handler
+            McpResponse response = requestHandler.handleRequest(request);
+
+            // Notifications return null (no response needed)
+            if (response == null) {
+                log.debug("Notification handled, no response needed");
+                return;
+            }
+
+            // Serialize response
+            String responseJson = requestHandler.serializeResponse(response);
+
+            // Write to stdout (must be pure JSON, no extra characters!)
+            stdout.println(responseJson);
+            stdout.flush(); // Ensure immediate delivery
+
+            // Log to stderr
+            log.debug("Sent: {}", responseJson);
+
+        } catch (Exception e) {
+            log.error("Error handling request: {}", jsonLine, e);
+
+            // Try to send error response
+            try {
+                McpResponse errorResponse = McpResponse.error(
+                    null, // Unknown request ID
+                    com.expense.mcp.protocol.McpError.parseError("Invalid JSON-RPC: " + e.getMessage())
+                );
+                String errorJson = requestHandler.serializeResponse(errorResponse);
+                stdout.println(errorJson);
+                stdout.flush();
+            } catch (Exception ex) {
+                log.error("Failed to send error response", ex);
+            }
+        }
+    }
+
+    /**
+     * Shutdown the stdio transport gracefully.
+     */
+    public void shutdown() {
+        if (!running.compareAndSet(true, false)) {
+            log.warn("Stdio transport not running");
+            return;
+        }
+
+        log.info("Shutting down MCP Stdio Transport...");
+        cleanup();
+    }
+
+    /**
+     * Clean up resources (streams).
+     */
+    private void cleanup() {
+        try {
+            if (stdin != null) {
+                stdin.close();
+            }
+            if (stdout != null) {
+                stdout.close();
+            }
+            log.info("MCP Stdio Transport stopped");
+        } catch (Exception e) {
+            log.error("Error during cleanup", e);
+        }
+    }
+
+    /**
+     * Check if transport is running.
+     */
+    public boolean isRunning() {
+        return running.get();
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/transport/McpWebSocketHandler.java
+++ b/mcp-server/src/main/java/com/expense/mcp/transport/McpWebSocketHandler.java
@@ -1,0 +1,80 @@
+package com.expense.mcp.transport;
+
+import com.expense.mcp.config.McpServerConfig;
+import com.expense.mcp.protocol.McpError;
+import com.expense.mcp.protocol.McpRequest;
+import com.expense.mcp.protocol.McpResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+/**
+ * WebSocket handler for MCP protocol.
+ * Handles WebSocket connections and routes messages to McpRequestHandler.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class McpWebSocketHandler extends TextWebSocketHandler {
+
+    private final McpRequestHandler requestHandler;
+    private final McpServerConfig serverConfig;
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        log.info("WebSocket connection established: sessionId={}", session.getId());
+        super.afterConnectionEstablished(session);
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        String payload = message.getPayload();
+        log.debug("Received WebSocket message: sessionId={}, payload={}", session.getId(), payload);
+
+        try {
+            // Parse request
+            McpRequest request = requestHandler.parseRequest(payload);
+
+            // Handle request
+            McpResponse response = requestHandler.handleRequest(request);
+
+            // Send response
+            String responseJson = requestHandler.serializeResponse(response);
+            session.sendMessage(new TextMessage(responseJson));
+
+            log.debug("Sent WebSocket response: sessionId={}, payload={}", session.getId(), responseJson);
+
+        } catch (Exception e) {
+            log.error("Error processing WebSocket message", e);
+
+            // Send error response
+            McpResponse errorResponse = McpResponse.error(
+                    null,
+                    McpError.parseError("Failed to parse request: " + e.getMessage())
+            );
+
+            try {
+                String errorJson = requestHandler.serializeResponse(errorResponse);
+                session.sendMessage(new TextMessage(errorJson));
+            } catch (Exception sendError) {
+                log.error("Failed to send error response", sendError);
+            }
+        }
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        log.info("WebSocket connection closed: sessionId={}, status={}", session.getId(), status);
+        super.afterConnectionClosed(session, status);
+    }
+
+    @Override
+    public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
+        log.error("WebSocket transport error: sessionId=" + session.getId(), exception);
+        super.handleTransportError(session, exception);
+    }
+}

--- a/mcp-server/src/main/java/com/expense/mcp/transport/WebSocketConfig.java
+++ b/mcp-server/src/main/java/com/expense/mcp/transport/WebSocketConfig.java
@@ -1,0 +1,37 @@
+package com.expense.mcp.transport;
+
+import com.expense.mcp.config.McpServerConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+/**
+ * WebSocket configuration for MCP server.
+ * Registers the WebSocket endpoint at the configured path (default: /mcp)
+ */
+@Configuration
+@EnableWebSocket
+@ConditionalOnProperty(prefix = "mcp.server.websocket", name = "enabled", havingValue = "true", matchIfMissing = true)
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final McpWebSocketHandler webSocketHandler;
+    private final McpServerConfig serverConfig;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        String path = serverConfig.getWebsocket().getPath();
+
+        log.info("Registering WebSocket handler at path: {}", path);
+
+        registry.addHandler(webSocketHandler, path)
+                .setAllowedOrigins("*"); // Configure CORS as needed
+
+        log.info("WebSocket endpoint registered successfully: ws://localhost:8082{}", path);
+    }
+}

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -1,0 +1,78 @@
+# MCP Server Configuration
+server:
+  port: 8082
+  servlet:
+    context-path: /
+
+spring:
+  application:
+    name: monthly-expense-mcp-server
+
+  # PostgreSQL Database configuration (KIND cluster via port-forward)
+  datasource:
+    url: ${DATABASE_URL:jdbc:postgresql://localhost:5432/monthly_expense_db}
+    username: ${DATABASE_USER:postgres}
+    password: ${DATABASE_PASSWORD:4bTp9VmJ0D%}
+    driver-class-name: org.postgresql.Driver
+
+    # Connection pooling
+    hikari:
+      minimum-idle: 5
+      maximum-pool-size: 10
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+        jdbc:
+          lob:
+            non_contextual_creation: true
+
+# MCP Server specific configuration
+mcp:
+  server:
+    enabled: true
+
+    websocket:
+      path: /mcp
+      enabled: true
+      max-message-size: 1048576  # 1MB
+      session-timeout: 300000     # 5 minutes
+
+    http:
+      enabled: true
+      path: /api/mcp
+
+    auth:
+      enabled: false  # Set to true in production
+      header-name: X-MCP-API-Key
+      api-keys:
+        # Add your API keys here (for production)
+        # - "your-secret-api-key-1"
+        # - "your-secret-api-key-2"
+
+# Logging
+logging:
+  level:
+    root: INFO
+    com.expense.mcp: DEBUG
+    com.expense.monthly: INFO
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss} - %msg%n"
+
+# Actuator endpoints
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+  endpoint:
+    health:
+      show-details: always

--- a/mcp-server/src/main/resources/logback-spring.xml
+++ b/mcp-server/src/main/resources/logback-spring.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!--
+        Logback Configuration for MCP Stdio Transport
+
+        CRITICAL: All logs MUST go to stderr (System.err) to keep stdout clean.
+        Claude Desktop reads pure JSON from stdout - any log messages will cause parse errors.
+
+        Output Streams:
+        - stdout (System.out) → Pure JSON-RPC responses ONLY
+        - stderr (System.err) → All logs (Spring Boot, application, MCP)
+    -->
+
+    <!-- Console appender that targets STDERR -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- CRITICAL: target must be System.err (not System.out) -->
+        <target>System.err</target>
+
+        <encoder>
+            <!-- Log pattern: timestamp, level, logger name, message -->
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <!-- Root logger configuration -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+    <!-- MCP-specific loggers (can be more verbose) -->
+    <logger name="com.expense.mcp" level="DEBUG" additivity="false">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    <!-- Spring Boot loggers (keep at INFO to reduce noise) -->
+    <logger name="org.springframework.boot" level="INFO" additivity="false">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    <!-- Reduce Hibernate SQL logging in stdio mode -->
+    <logger name="org.hibernate.SQL" level="WARN" additivity="false">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    <!-- Reduce HikariCP connection pool logging -->
+    <logger name="com.zaxxer.hikari" level="WARN" additivity="false">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    <!--
+        Profile-specific configurations (optional)
+
+        For web mode (HTTP/WebSocket), you might want different logging.
+        We'll keep stderr for consistency, but you can create profile-specific configs if needed.
+    -->
+</configuration>

--- a/mcp-server/start-mcp-kind.sh
+++ b/mcp-server/start-mcp-kind.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+#
+# Start MCP Server connected to KIND PostgreSQL
+#
+
+set -e
+
+echo "========================================="
+echo "Starting MCP Server with KIND PostgreSQL"
+echo "========================================="
+echo ""
+
+cd "$(dirname "$0")"
+
+# Check if kubectl is available
+if ! command -v kubectl &> /dev/null; then
+    echo "❌ kubectl not found. Please install kubectl."
+    exit 1
+fi
+
+# Check if KIND cluster is running
+if ! kubectl get nodes &> /dev/null; then
+    echo "❌ KIND cluster not accessible. Please start Docker Desktop and KIND cluster."
+    exit 1
+fi
+
+# Check if PostgreSQL pod is running
+if ! kubectl get pod -n monthly-expense monthly-expense-postgresql-0 &> /dev/null; then
+    echo "❌ PostgreSQL pod not found in KIND cluster."
+    exit 1
+fi
+
+echo "✅ KIND cluster is accessible"
+echo "✅ PostgreSQL pod is running"
+echo ""
+
+# Check if port-forward is already running
+if lsof -i :5432 &> /dev/null; then
+    echo "✅ Port 5432 is already forwarded"
+else
+    echo "Starting PostgreSQL port forward..."
+    kubectl port-forward -n monthly-expense service/monthly-expense-postgresql 5432:5432 > /tmp/postgres-port-forward.log 2>&1 &
+    PF_PID=$!
+    echo "✅ Port forward started (PID: $PF_PID)"
+    sleep 3
+fi
+
+echo ""
+
+# Check if MCP server is already running
+if lsof -i :8082 &> /dev/null; then
+    echo "⚠️  MCP server is already running on port 8082"
+    read -p "Do you want to restart it? (y/N): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        pkill -f "mcp-server-1.0.0.jar" || true
+        sleep 2
+    else
+        echo "Keeping existing MCP server running."
+        exit 0
+    fi
+fi
+
+echo "Starting MCP server..."
+java -jar target/mcp-server-1.0.0.jar \
+  --spring.config.location=file:./application-postgres.properties \
+  > /tmp/mcp-server.log 2>&1 &
+
+MCP_PID=$!
+echo "✅ MCP server started (PID: $MCP_PID)"
+echo ""
+
+sleep 10
+
+# Verify MCP server is running
+if lsof -i :8082 &> /dev/null; then
+    echo "========================================="
+    echo "✅ MCP Server Started Successfully!"
+    echo "========================================="
+    echo ""
+    echo "Endpoints:"
+    echo "  WebSocket: ws://localhost:8082/mcp"
+    echo "  HTTP:      http://localhost:8082/api/mcp"
+    echo "  Health:    http://localhost:8082/actuator/health"
+    echo ""
+    echo "Database:"
+    echo "  KIND PostgreSQL (port-forwarded from cluster)"
+    echo "  Database: monthly_expense_db"
+    echo "  Username: postgres"
+    echo ""
+    echo "Tools Registered: 6"
+    echo "  - query_expenses"
+    echo "  - get_category_totals"
+    echo "  - get_monthly_summary"
+    echo "  - get_total_spending"
+    echo "  - search_transactions"
+    echo "  - get_primary_currency"
+    echo ""
+    echo "Logs:"
+    echo "  MCP Server:    tail -f /tmp/mcp-server.log"
+    echo "  Port Forward:  tail -f /tmp/postgres-port-forward.log"
+    echo ""
+    echo "To stop:"
+    echo "  kill $MCP_PID"
+    echo "  pkill -f 'port-forward.*postgresql'"
+    echo "========================================="
+else
+    echo "❌ MCP server failed to start. Check logs:"
+    echo "  tail -50 /tmp/mcp-server.log"
+    exit 1
+fi

--- a/mcp-server/stop-mcp-kind.sh
+++ b/mcp-server/stop-mcp-kind.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+#
+# Stop MCP Server and PostgreSQL port-forward
+#
+
+echo "Stopping MCP Server and PostgreSQL port-forward..."
+echo ""
+
+# Stop MCP server
+MCP_PID=$(lsof -ti :8082)
+if [ -n "$MCP_PID" ]; then
+    echo "Stopping MCP Server (PID: $MCP_PID)..."
+    kill $MCP_PID 2>/dev/null || true
+    echo "✅ MCP Server stopped"
+else
+    echo "⚠️  MCP Server not running"
+fi
+
+# Stop port-forward
+PF_PID=$(ps aux | grep 'port-forward.*postgresql' | grep -v grep | awk '{print $2}')
+if [ -n "$PF_PID" ]; then
+    echo "Stopping PostgreSQL port-forward (PID: $PF_PID)..."
+    kill $PF_PID 2>/dev/null || true
+    echo "✅ Port-forward stopped"
+else
+    echo "⚠️  PostgreSQL port-forward not running"
+fi
+
+echo ""
+echo "========================================="
+echo "✅ All services stopped"
+echo "========================================="


### PR DESCRIPTION
Implements a complete Model Context Protocol (MCP) server that enables Claude Desktop to interact with the Monthly Expense Tracker database using natural language queries.

## Key Features

### MCP Server Core
- Automatic tool discovery via @McpTool annotations
- 6 expense analysis tools (query, totals, summaries, search)
- JSON-RPC 2.0 protocol implementation
- Type-safe parameter conversion and validation

### Transport Layers
- **Stdio transport**: For Claude Desktop (stdin/stdout pipes)
- **HTTP transport**: REST API endpoint at /api/mcp
- **WebSocket transport**: Real-time endpoint at ws://localhost:8082/mcp
- Automatic mode detection (stdio vs web)

### Stdio Transport Fixes
- Single-line JSON output (no pretty-printing for line-by-line parsing)
- All logs redirected to stderr (keeps stdout clean for JSON-RPC)
- MCP notification handling (notifications/initialized, notifications/cancelled)
- Removed invalid "success" field from responses (@JsonIgnore on helper methods)
- Initialization delay to prevent timeout on first request

### Architecture
- Reuses all backend services (TransactionService, repositories)
- Spring Boot non-web mode for stdio transport
- Separate configuration profiles for stdio vs web modes
- PostgreSQL connection with HikariCP pooling

### Documentation
- Complete setup guides for Claude Desktop and KIND deployment
- Usage examples and testing instructions
- Troubleshooting guides with common issues

### Files Added
- mcp-server/ - Complete MCP server implementation (23 Java classes)
- .claude/ - Project instructions for Claude Code
- Logback configuration for stderr logging
- Shell scripts for setup and deployment

Tested and working with Claude Desktop - successfully processes natural language queries about expenses and returns data from PostgreSQL database.